### PR TITLE
Backstage template updates Gitlab self-service repo

### DIFF
--- a/catalogs/argocd/setup-root-self-service-repository/skeleton/catalog-info.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/skeleton/catalog-info.yaml
@@ -14,4 +14,4 @@ metadata:
 spec:
   type: service
   lifecycle: production
-  owner: {{ values.owner }}
+  owner: ${{ values.owner }}

--- a/catalogs/argocd/setup-root-self-service-repository/skeleton/catalog-info.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/skeleton/catalog-info.yaml
@@ -14,4 +14,4 @@ metadata:
 spec:
   type: service
   lifecycle: production
-  owner: ${{ user.entity }}
+  owner: devops-team

--- a/catalogs/argocd/setup-root-self-service-repository/skeleton/catalog-info.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/skeleton/catalog-info.yaml
@@ -10,8 +10,8 @@ metadata:
   annotations:
     argocd/app-selector: backstage-name=root-self-service
     backstage.io/techdocs-ref: dir:.
-    gitlab.com/project-slug: ${{ parameters.gitlabOwner }}/${{ parameters.gitlabRepository }}
+    gitlab.com/project-slug: ${{ values.gitlabProjectSlug }}
 spec:
   type: service
   lifecycle: production
-  owner: user:${{ user.entity.metadata.namespace}}/${{ user.entity.metadata.name }}
+  owner: {{ values.owner }}

--- a/catalogs/argocd/setup-root-self-service-repository/skeleton/catalog-info.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/skeleton/catalog-info.yaml
@@ -13,6 +13,5 @@ metadata:
     gitlab.com/project-slug: self-service/root-self-service-repository
 spec:
   type: service
-  system: root-self-service
   lifecycle: production
-  owner: devops-team
+  owner: ${{ user.entity }}

--- a/catalogs/argocd/setup-root-self-service-repository/skeleton/catalog-info.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/skeleton/catalog-info.yaml
@@ -11,6 +11,7 @@ metadata:
     argocd/app-selector: backstage-name=root-self-service
     backstage.io/techdocs-ref: dir:.
     gitlab.com/project-slug: ${{ values.gitlabProjectSlug }}
+    gitlab.com/instance: ${{ values.gitlabInstance }}
 spec:
   type: service
   lifecycle: production

--- a/catalogs/argocd/setup-root-self-service-repository/skeleton/catalog-info.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/skeleton/catalog-info.yaml
@@ -8,10 +8,10 @@ metadata:
     It enables teams to attach their team-based repositories and synchronize applications with 
     the root repository, ensuring a streamlined continuous deployment process via ArgoCD.
   annotations:
-    argocd/app-name: root-self-service-repository
+    argocd/app-selector: backstage-name=root-self-service
     backstage.io/techdocs-ref: dir:.
-    gitlab.com/project-slug: self-service/root-self-service-repository
+    gitlab.com/project-slug: ${{ parameters.gitlabOwner }}/${{ parameters.gitlabRepository }}
 spec:
   type: service
   lifecycle: production
-  owner: devops-team
+  owner: ${{ user.entity }}

--- a/catalogs/argocd/setup-root-self-service-repository/skeleton/catalog-info.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/skeleton/catalog-info.yaml
@@ -14,4 +14,4 @@ metadata:
 spec:
   type: service
   lifecycle: production
-  owner: ${{ user.entity }}
+  owner: user:${{ user.entity.metadata.namespace}}/${{ user.entity.metadata.name }}

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -102,6 +102,8 @@ spec:
           domain: ${{ steps['fetchArgoEntity'].output.entity.spec.cluster }}
           path: "projects"
           projectName: "system"
+          owner: user:${{ user.entity.metadata.namespace}}/${{ user.entity.metadata.name }}
+          gitlabProjectSlug: ${{ parameters.gitlabOwner }}/${{ parameters.gitlabRepository }}
 
     #################################
     ## Create Self-Service Repository

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -99,7 +99,7 @@ spec:
           - ${{ parameters.gitlabInstance.entity | parseEntityRef }}
         description: |
           Self-Service Repository
-        repoUrl: ${{ parameters.gitlabInstance.entity }}
+        repoUrl: ${{ parameters.gitlabInstance }}
         #repoUrl: gitlab.consulting.redhat.com?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
         #repoUrl: ${{ parameters.gitlabInstance | parseEntityRef }}?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
         defaultBranch: main

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -104,6 +104,7 @@ spec:
           projectName: "system"
           owner: user:${{ user.entity.metadata.namespace}}/${{ user.entity.metadata.name }}
           gitlabProjectSlug: ${{ parameters.gitlabOwner }}/${{ parameters.gitlabRepository }}
+          gitlabInstance: ${{ steps['fetchGitlabEntity'].output.entity.spec.url }}
 
     #################################
     ## Create Self-Service Repository

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -82,7 +82,7 @@ spec:
           - ${{ parameters.gitlabInstance.spec.url | 'gitlab.com' }}
         description: |
           Self-Service Repository
-        repoUrl: ${{ parameters.gitlabInstance | 'gitlab.com' }}?owner=self-provisioned&repo=manifests
+        repoUrl: ${{ parameters.gitlabInstance.spec.url | 'gitlab.com' }}?owner=self-provisioned&repo=manifests
         defaultBranch: main
 
     #################################

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -96,7 +96,7 @@ spec:
       action: publish:gitlab
       input:
         allowedHosts:
-          - ${{ parameters.gitlabInstance | parseEntityRef }}
+          - ${{ parameters.gitlabInstance.entity.metadata.name | parseEntityRef }}
         description: |
           Self-Service Repository
         repoUrl: ${{ parameters.gitlabInstance.entity.metadata.name }}

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -48,7 +48,11 @@ spec:
           title: GitLab Instance
           type: string
           description: GitLab instance
-          default: gitlab.com
+          ui:field: EntityPicker
+          ui:options:
+            catalogFilter:
+              - kind: Resource
+                spec.type: gitlab
         gitlabOwner:
           title: GitLab Owner
           type: string
@@ -67,21 +71,11 @@ spec:
 
   steps:
 
-    #######################
-    ## Request Dynamic Data
-    #######################
-    - id: requestDynamicData
-      name: "Fetch Dynamic Data"
-      action: http:backstage:request
+    - action: catalog:fetch
+      id: fetchGitlabEntity
+      name: Fetch Gitlab Entity
       input:
-        method: 'POST'
-        path: 'proxy/data/fetch'
-        headers:
-          Content-Type: 'application/json'
-        body: |
-          {
-            "request": ["DOMAIN"]
-          }
+        entityRef: ${{ parameters.gitlabInstance }}
 
     ##########################
     ## Template the Repository
@@ -98,7 +92,7 @@ spec:
           - projects
         values:
           targetRevision: "main"
-          domain: ${{ steps.requestDynamicData.output.body["DOMAIN"] }}
+          domain: kechung.tamlab.rdu2.redhat.com # ${{ ${{ steps.requestDynamicData.output.body["DOMAIN"] }}
           path: "projects"
           projectName: "system"
 
@@ -110,10 +104,10 @@ spec:
       action: publish:gitlab
       input:
         allowedHosts:
-          - ${{ parameters.gitlabInstance }}
+          - ${{ steps['fetchGitlabEntity'].output.entity.spec.domain.url | 'gitlab.com' }}
         description: |
           Self-Service Repository
-        repoUrl: ${{ parameters.gitlabInstance }}?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
+        repoUrl: ${{ steps['fetchGitlabEntity'].output.entity.spec.domain.url | 'gitlab2.com' }}?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
         #repoUrl: gitlab.consulting.redhat.com?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
         defaultBranch: ${{ parameters.gitlabBranch | main }}
 

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -74,6 +74,12 @@ spec:
 
   steps:
 
+    - id: debug
+      name: Debug
+      action: debug:log
+      input:
+        message: ${{ user.entity | dump }}
+
     - action: catalog:fetch
       id: fetchArgoEntity
       name: Fetch ArgoCD Entity
@@ -96,7 +102,6 @@ spec:
         copyWithoutTemplating:
           - README.md
           - LICENSE
-          - catalog-info.yaml
           - projects
         values:
           targetRevision: "main"

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -79,7 +79,15 @@ spec:
           domain: ${{ parameters.argoInstance.spec.domain | parseEntityRef }}
           path: "projects"
           projectName: "system"
- 
+
+
+    - id: debug
+      name: Debug
+      action: debug:log
+      input:
+        extra: ${{ parameters.gitlabInstance | ParseEntityRef }}
+
+
     #################################
     ## Create Self-Service Repository
     #################################
@@ -88,11 +96,11 @@ spec:
       action: publish:gitlab
       input:
         allowedHosts:
-          - ${{ parameters.gitlabInstance.spec.url | parseEntityRef }}
+          - ${{ parameters.gitlabInstance | parseEntityRef }}
         description: |
           Self-Service Repository
         #repoUrl: gitlab.consulting.redhat.com?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
-        repoUrl: ${{ parameters.gitlabInstance.spec.url | parseEntityRef }}?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
+        repoUrl: ${{ parameters.gitlabInstance | parseEntityRef }}?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
         defaultBranch: main
 
     #################################
@@ -103,7 +111,7 @@ spec:
       action: argocd:create-resources
       input:
         appName: "root-self-service"
-        argoInstance: ${{ parameters.argoInstance.spec.url | parseEntityRef }}
+        argoInstance: ${{ parameters.argoInstance | parseEntityRef }}
         namespace: "openshift-gitops"
         repoUrl: "${{ steps['publish'].output.remoteUrl }}.git"
         path: "_init_"
@@ -121,6 +129,6 @@ spec:
   output:
     links:
       - title: GitOps Application
-        url: ${{ parameters.argoInstance.spec.url | parseEntityRef }}/applications/openshift-gitops/root-self-service
+        url: ${{ parameters.argoInstance | parseEntityRef }}/applications/openshift-gitops/root-self-service
       - title: GitLab Repository
         url: ${{ steps['publish'].output.remoteUrl }}

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -74,12 +74,6 @@ spec:
 
   steps:
 
-    - id: debug
-      name: Debug
-      action: debug:log
-      input:
-        message: ${{ user.entity | dump }}
-
     - action: catalog:fetch
       id: fetchArgoEntity
       name: Fetch ArgoCD Entity

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -96,6 +96,7 @@ spec:
         copyWithoutTemplating:
           - README.md
           - LICENSE
+          - catalog-info.yaml
           - projects
         values:
           targetRevision: "main"

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -104,10 +104,10 @@ spec:
       action: publish:gitlab
       input:
         allowedHosts:
-          - ${{ steps['fetchGitlabEntity'].output.entity.spec.domain.url | 'gitlab.com' }}
+          - ${{ steps['fetchGitlabEntity'].output.entity.spec.domain.url | dump }}
         description: |
           Self-Service Repository
-        repoUrl: ${{ steps['fetchGitlabEntity'].output.entity.spec.domain.url | 'gitlab2.com' }}?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
+        repoUrl: ${{ steps['fetchGitlabEntity'].output.entity.spec.domain.url | dump }}?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
         #repoUrl: gitlab.consulting.redhat.com?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
         defaultBranch: ${{ parameters.gitlabBranch | main }}
 

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -76,7 +76,7 @@ spec:
           - projects
         values:
           targetRevision: "main"
-          domain: ${{ parameters.argoInstance.spec.domain }}
+          domain: ${{ parameters.argoInstance.spec.domain | parseEntityRef }}
           path: "projects"
           projectName: "system"
  
@@ -88,11 +88,11 @@ spec:
       action: publish:gitlab
       input:
         allowedHosts:
-          - ${{ parameters.gitlabInstance.spec.url | 'gitlab.com' }}
+          - ${{ parameters.gitlabInstance.spec.url | parseEntityRef }}
         description: |
           Self-Service Repository
-        repoUrl: gitlab.consulting.redhat.com?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
-        #repoUrl: ${{ parameters.gitlabInstance.spec.url | 'gitlab.com' }}?owner=self-provisioned&repo=manifests
+        #repoUrl: gitlab.consulting.redhat.com?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
+        repoUrl: ${{ parameters.gitlabInstance.spec.url | parseEntityRef }}?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
         defaultBranch: main
 
     #################################
@@ -103,7 +103,7 @@ spec:
       action: argocd:create-resources
       input:
         appName: "root-self-service"
-        argoInstance: ${{ parameters.argoInstance.spec.url }}
+        argoInstance: ${{ parameters.argoInstance.spec.url | parseEntityRef }}
         namespace: "openshift-gitops"
         repoUrl: "${{ steps['publish'].output.remoteUrl }}.git"
         path: "_init_"
@@ -121,6 +121,6 @@ spec:
   output:
     links:
       - title: GitOps Application
-        url: ${{ parameters.argoInstance.spec.url }}/applications/openshift-gitops/root-self-service
+        url: ${{ parameters.argoInstance.spec.url | parseEntityRef }}/applications/openshift-gitops/root-self-service
       - title: GitLab Repository
         url: ${{ steps['publish'].output.remoteUrl }}

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -82,7 +82,8 @@ spec:
           - ${{ parameters.gitlabInstance.spec.url | 'gitlab.com' }}
         description: |
           Self-Service Repository
-        repoUrl: ${{ parameters.gitlabInstance.spec.url | 'gitlab.com' }} + '?owner=self-provisioned&repo=manifests'
+        repoUrl: gitlab.consulting.redhat.com?owner=self-provisioned&repo=manifests
+        #repoUrl: ${{ parameters.gitlabInstance.spec.url | 'gitlab.com' }}?owner=self-provisioned&repo=manifests
         defaultBranch: main
 
     #################################

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -47,7 +47,7 @@ spec:
       action: http:backstage:request
       input:
         method: 'POST'
-        path: 'proxy/data/fetch'
+        path: '/proxy/data/fetch'
         headers:
           Content-Type: 'application/json'
         body: |

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -96,7 +96,6 @@ spec:
         copyWithoutTemplating:
           - README.md
           - LICENSE
-          - catalog-info.yaml
           - projects
         values:
           targetRevision: "main"
@@ -149,3 +148,6 @@ spec:
         url: https://${{ steps['fetchArgoEntity'].output.entity.spec.url }}/applications/openshift-gitops/root-self-service
       - title: GitLab Repository
         url: ${{ steps['publish'].output.remoteUrl }}
+      - title: Open in catalog
+        icon: catalog
+        entityRef: ${{ steps['register'].output.entityRef }}

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -110,14 +110,11 @@ spec:
       action: publish:gitlab
       input:
         allowedHosts:
-          - 'gitlab.consulting.redhat.com'
-#          - ${{ steps['fetchGitlabEntity'].output.entity.spec.url }}
+          - ${{ steps['fetchGitlabEntity'].output.entity.spec.url }}
         description: |
           Self-Service Repository
-        #repoUrl: ${{ steps['fetchGitlabEntity'].output.entity.spec.url }}?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
-        repoUrl: gitlab.consulting.redhat.com?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
-        #defaultBranch: ${{ parameters.gitlabBranch }}
-        defaultBranch: main
+        repoUrl: ${{ steps['fetchGitlabEntity'].output.entity.spec.url }}?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
+        defaultBranch: ${{ parameters.gitlabBranch }}
 
     #################################
     ## ArgoCD Resources Configuration

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -99,8 +99,9 @@ spec:
           - ${{ parameters.gitlabInstance | parseEntityRef }}
         description: |
           Self-Service Repository
+        repoUrl: ${{ parameters.gitlabInstance.entity.metadata.name }}
         #repoUrl: gitlab.consulting.redhat.com?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
-        repoUrl: ${{ parameters.gitlabInstance | parseEntityRef }}?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
+        #repoUrl: ${{ parameters.gitlabInstance | parseEntityRef }}?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
         defaultBranch: main
 
     #################################

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -82,7 +82,7 @@ spec:
           - ${{ parameters.gitlabInstance.spec.url | 'gitlab.com' }}
         description: |
           Self-Service Repository
-        repoUrl: ${{ parameters.gitlabInstance.spec.url | 'gitlab.com' }}?owner=self-provisioned&repo=manifests
+        repoUrl: ${{ parameters.gitlabInstance.spec.url | 'gitlab.com' }} + '?owner=self-provisioned&repo=manifests'
         defaultBranch: main
 
     #################################

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -117,8 +117,8 @@ spec:
           Self-Service Repository
         repoUrl: ${{ steps['fetchGitlabEntity'].output.entity.spec.url }}?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
         defaultBranch: ${{ parameters.gitlabBranch }}
-      settings:
-        visibility: "public"
+        settings:
+          visibility: "public"
 
     #################################
     ## ArgoCD Resources Configuration

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -33,23 +33,32 @@ spec:
       properties:
         argoInstance:
           title: ArgoCD Instance
-          description: The ArgoCD instance that will manage this application. Choose from available instances.
+          type: string
+          description: The ArgoCD instance that will manage this application
           ui:field: EntityPicker
           ui:options:
             catalogFilter:
               - kind: System
                 spec.type: argocd
-          type: string
         gitlabInstance:
           title: GitLab Instance
-          description: The GitLab instance to create a self-service repository in.
+          type: string
+          description: The GitLab instance to create a self-service repository in
           ui:field: EntityPicker
           ui:options:
             catalogFilter:
               - kind: System
                 spec.type: gitlab
+        gitlabOwner:
+          title: GitLab Owner
           type: string
-
+          default: self-provisioned
+          description: The GitLab repository owner
+        gitlabRepository:
+          title: GitLab Repository
+          type: string
+          default: manifests
+          description: The GitLab self-service repository
   steps:
 
     ##########################
@@ -82,7 +91,7 @@ spec:
           - ${{ parameters.gitlabInstance.spec.url | 'gitlab.com' }}
         description: |
           Self-Service Repository
-        repoUrl: gitlab.consulting.redhat.com?owner=self-provisioned&repo=manifests
+        repoUrl: gitlab.consulting.redhat.com?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
         #repoUrl: ${{ parameters.gitlabInstance.spec.url | 'gitlab.com' }}?owner=self-provisioned&repo=manifests
         defaultBranch: main
 

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -110,12 +110,14 @@ spec:
       action: publish:gitlab
       input:
         allowedHosts:
-          - ${{ steps['fetchGitlabEntity'].output.entity.spec.url }}
+          - 'gitlab.consulting.redhat.com'
+#          - ${{ steps['fetchGitlabEntity'].output.entity.spec.url }}
         description: |
           Self-Service Repository
-        repoUrl: ${{ steps['fetchGitlabEntity'].output.entity.spec.url }}?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
-        #repoUrl: gitlab.consulting.redhat.com?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
-        defaultBranch: ${{ parameters.gitlabBranch }}
+        #repoUrl: ${{ steps['fetchGitlabEntity'].output.entity.spec.url }}?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
+        repoUrl: gitlab.consulting.redhat.com?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
+        #defaultBranch: ${{ parameters.gitlabBranch }}
+        defaultBranch: main
 
     #################################
     ## ArgoCD Resources Configuration

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -117,7 +117,8 @@ spec:
           Self-Service Repository
         repoUrl: ${{ steps['fetchGitlabEntity'].output.entity.spec.url }}?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
         defaultBranch: ${{ parameters.gitlabBranch }}
-        settings.visibility: 'public'
+        settings:
+          visibility: 'public'
 
     #################################
     ## ArgoCD Resources Configuration

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -32,10 +32,13 @@ spec:
       properties:
         argoInstance:
           title: ArgoCD Instance
-          description: The ArgoCD instance that will manage this application. Choose from available instances.
-          enum:
-            - main
           type: string
+          description: The ArgoCD instance that will manage this application. Choose from available instances.
+          ui:field: EntityPicker
+          ui:options:
+            catalogFilter:
+              - kind: Resource
+                spec.type: argocd
 
     - title: GitLab Repository Information
       required:
@@ -72,6 +75,11 @@ spec:
   steps:
 
     - action: catalog:fetch
+      id: fetchArgoEntity
+      name: Fetch ArgoCD Entity
+      input:
+        entityRef: ${{ parameters.argoInstance }}
+    - action: catalog:fetch
       id: fetchGitlabEntity
       name: Fetch Gitlab Entity
       input:
@@ -81,7 +89,7 @@ spec:
       name: Log Message
       action: debug:log
       input:
-        message: ${{ steps['fetchGitlabEntity'].output.entity.spec.url | dump }}
+        message: ${{ steps['fetchArgoEntity'].output.entity.spec.url | dump }}
 
     ##########################
     ## Template the Repository
@@ -98,7 +106,7 @@ spec:
           - projects
         values:
           targetRevision: "main"
-          domain: kechung.tamlab.rdu2.redhat.com # ${{ ${{ steps.requestDynamicData.output.body["DOMAIN"] }}
+          domain: ${{ steps['fetchArgoEntity'].output.entity.spec.cluster }}
           path: "projects"
           projectName: "system"
 
@@ -124,7 +132,7 @@ spec:
       action: argocd:create-resources
       input:
         appName: "root-self-service"
-        argoInstance: ${{ parameters.argoInstance }}
+        argoInstance: ${{ steps['fetchArgoEntity'].output.entity.spec.url }}
         namespace: "openshift-gitops"
         repoUrl: "${{ steps['publish'].output.remoteUrl }}.git"
         path: "_init_"
@@ -142,6 +150,6 @@ spec:
   output:
     links:
       - title: GitOps Application
-        url: https://openshift-gitops-server-openshift-gitops.apps.${{ steps['requestDynamicData'].output.body["DOMAIN"] }}/applications/openshift-gitops/root-self-service
+        url: https://${{ steps['fetchArgoEntity'].output.entity.spec.url }}/applications/openshift-gitops/root-self-service
       - title: GitLab Repository
         url: ${{ steps['publish'].output.remoteUrl }}

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -79,10 +79,10 @@ spec:
       action: publish:gitlab
       input:
         allowedHosts:
-          - ${{ parameters.gitlabInstance }}
+          - ${{ parameters.gitlabInstance.spec.url | 'gitlab.com' }}
         description: |
           Self-Service Repository
-        repoUrl: ${{ parameters.gitlabInstance }}?owner=self-provisioned&repo=manifests
+        repoUrl: ${{ parameters.gitlabInstance | 'gitlab.com' }}?owner=self-provisioned&repo=manifests
         defaultBranch: main
 
     #################################
@@ -93,7 +93,7 @@ spec:
       action: argocd:create-resources
       input:
         appName: "root-self-service"
-        argoInstance: ${{ parameters.argoInstance }}
+        argoInstance: ${{ parameters.argoInstance.spec.url }}
         namespace: "openshift-gitops"
         repoUrl: "${{ steps['publish'].output.remoteUrl }}.git"
         path: "_init_"
@@ -111,6 +111,6 @@ spec:
   output:
     links:
       - title: GitOps Application
-        url: ${{ parameters.argoInstance }}/applications/openshift-gitops/root-self-service
+        url: ${{ parameters.argoInstance.spec.url }}/applications/openshift-gitops/root-self-service
       - title: GitLab Repository
         url: ${{ steps['publish'].output.remoteUrl }}

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -117,6 +117,7 @@ spec:
           Self-Service Repository
         repoUrl: ${{ steps['fetchGitlabEntity'].output.entity.spec.url }}?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
         defaultBranch: ${{ parameters.gitlabBranch }}
+        settings.visibility: 'public'
 
     #################################
     ## ArgoCD Resources Configuration

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -117,10 +117,10 @@ spec:
       action: publish:gitlab
       input:
         allowedHosts:
-          - ${{ steps['fetchGitlabEntity'].output.entity.spec.url | 'gitlab.com' }}
+          - ${{ steps['fetchGitlabEntity'].output.entity.spec.url }}
         description: |
           Self-Service Repository
-        repoUrl: ${{ steps['fetchGitlabEntity'].output.entity.spec.url | 'gitlab.com' }}?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
+        repoUrl: ${{ steps['fetchGitlabEntity'].output.entity.spec.url }}?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
         #repoUrl: gitlab.consulting.redhat.com?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
         defaultBranch: ${{ parameters.gitlabBranch | main }}
 

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -117,6 +117,8 @@ spec:
           Self-Service Repository
         repoUrl: ${{ steps['fetchGitlabEntity'].output.entity.spec.url }}?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
         defaultBranch: ${{ parameters.gitlabBranch }}
+      settings:
+        visibility: "public"
 
     #################################
     ## ArgoCD Resources Configuration

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -82,10 +82,10 @@ spec:
       action: publish:gitlab
       input:
         allowedHosts:
-          - 'gitlab.com'
+          - 'gitlab.consulting.redhat.com'
         description: |
           Self-Service Repository
-        repoUrl: gitlab.com?owner=self-provisioned&repo=manifests
+        repoUrl: gitlab.consulting.redhat.com?owner=self-provisioned&repo=manifests
         defaultBranch: main
 
     #################################

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -150,4 +150,4 @@ spec:
         url: ${{ steps['publish'].output.remoteUrl }}
       - title: Open in catalog
         icon: catalog
-        entityRef: ${{ steps['register'].output.entityRef }}
+        entityRef: ${{ steps['registerCatalog'].output.entityRef }}

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -85,12 +85,6 @@ spec:
       input:
         entityRef: ${{ parameters.gitlabInstance }}
 
-    - id: log-message
-      name: Log Message
-      action: debug:log
-      input:
-        message: ${{ steps['fetchArgoEntity'].output.entity.spec.url | dump }}
-
     ##########################
     ## Template the Repository
     ##########################
@@ -132,7 +126,7 @@ spec:
       action: argocd:create-resources
       input:
         appName: "root-self-service"
-        argoInstance: ${{ steps['fetchArgoEntity'].output.entity.spec.url }}
+        argoInstance: ${{ steps['fetchArgoEntity'].output.entity.spec.instance }}
         namespace: "openshift-gitops"
         repoUrl: "${{ steps['publish'].output.remoteUrl }}.git"
         path: "_init_"

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -91,7 +91,7 @@ spec:
           - ${{ parameters.gitlabInstance | parseEntityRef | pick('name') }}
         description: |
           Self-Service Repository
-        repoUrl: ${{ parameters.gitlabInstance | parseEntityRef | pick('name') }}
+        repoUrl: ${{ parameters.gitlabInstance | parseEntityRef | pick('name') }}?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
         #repoUrl: gitlab.consulting.redhat.com?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
         #repoUrl: ${{ parameters.gitlabInstance | parseEntityRef }}?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
         defaultBranch: main

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -117,8 +117,6 @@ spec:
           Self-Service Repository
         repoUrl: ${{ steps['fetchGitlabEntity'].output.entity.spec.url }}?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
         defaultBranch: ${{ parameters.gitlabBranch }}
-        settings:
-          visibility: 'public'
 
     #################################
     ## ArgoCD Resources Configuration

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -96,10 +96,10 @@ spec:
       action: publish:gitlab
       input:
         allowedHosts:
-          - ${{ parameters.gitlabInstance.entity.metadata.name | parseEntityRef }}
+          - ${{ parameters.gitlabInstance.entity | parseEntityRef }}
         description: |
           Self-Service Repository
-        repoUrl: ${{ parameters.gitlabInstance.entity.metadata.name }}
+        repoUrl: ${{ parameters.gitlabInstance.entity }}
         #repoUrl: gitlab.consulting.redhat.com?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
         #repoUrl: ${{ parameters.gitlabInstance | parseEntityRef }}?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
         defaultBranch: main

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -77,6 +77,22 @@ spec:
       input:
         entityRef: ${{ parameters.gitlabInstance }}
 
+
+    - id: log-message
+      name: Log Message
+      action: debug:log
+      input:
+        message: ${{ steps['fetchGitlabEntity'] | dump }}
+
+    - id: log2-message
+      name: Log2 Message
+      action: debug:log
+      input:
+        message: ${{ steps['fetchGitlabEntity'].output.entity.spec.domain.url | dump }}
+
+
+
+
     ##########################
     ## Template the Repository
     ##########################

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -29,31 +29,28 @@ spec:
       ui:group: argocd
       required:
         - argoInstance
+        - gitlabInstance
       properties:
         argoInstance:
           title: ArgoCD Instance
           description: The ArgoCD instance that will manage this application. Choose from available instances.
-          enum:
-            - main
+          ui:field: EntityPicker
+          ui:options:
+            catalogFilter:
+              - kind: System
+                spec.type: argocd
+          type: string
+        gitlabInstance:
+          title: GitLab Instance
+          description: The GitLab instance to create a self-service repository in.
+          ui:field: EntityPicker
+          ui:options:
+            catalogFilter:
+              - kind: System
+                spec.type: gitlab
           type: string
 
   steps:
-
-    #######################
-    ## Request Dynamic Data
-    #######################
-    - id: requestDynamicData
-      name: "Fetch Dynamic Data"
-      action: http:backstage:request
-      input:
-        method: 'POST'
-        path: '/proxy/data/fetch'
-        headers:
-          Content-Type: 'application/json'
-        body: |
-          {
-            "request": ["DOMAIN"]
-          }
 
     ##########################
     ## Template the Repository
@@ -70,7 +67,7 @@ spec:
           - projects
         values:
           targetRevision: "main"
-          domain: ${{ steps.requestDynamicData.output.body["DOMAIN"] }}
+          domain: ${{ parameters.argoInstance.spec.domain }}
           path: "projects"
           projectName: "system"
  
@@ -82,10 +79,10 @@ spec:
       action: publish:gitlab
       input:
         allowedHosts:
-          - 'gitlab.consulting.redhat.com'
+          - ${{ parameters.gitlabInstance }}
         description: |
           Self-Service Repository
-        repoUrl: gitlab.consulting.redhat.com?owner=self-provisioned&repo=manifests
+        repoUrl: ${{ parameters.gitlabInstance }}?owner=self-provisioned&repo=manifests
         defaultBranch: main
 
     #################################
@@ -114,6 +111,6 @@ spec:
   output:
     links:
       - title: GitOps Application
-        url: https://openshift-gitops-server-openshift-gitops.apps.${{ steps['requestDynamicData'].output.body["DOMAIN"] }}/applications/openshift-gitops/root-self-service
+        url: ${{ parameters.argoInstance }}/applications/openshift-gitops/root-self-service
       - title: GitLab Repository
         url: ${{ steps['publish'].output.remoteUrl }}

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -82,12 +82,6 @@ spec:
       name: Log Message
       action: debug:log
       input:
-        message: ${{ steps['fetchGitlabEntity'] | dump }}
-
-    - id: log2-message
-      name: Log2 Message
-      action: debug:log
-      input:
         message: ${{ steps['fetchGitlabEntity'].output.entity.spec.url | dump }}
 
     ##########################
@@ -120,8 +114,8 @@ spec:
           - ${{ steps['fetchGitlabEntity'].output.entity.spec.url }}
         description: |
           Self-Service Repository
-        repoUrl: ${{ steps['fetchGitlabEntity'].output.entity.spec.url }}?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
-        #repoUrl: gitlab.consulting.redhat.com?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
+        #repoUrl: ${{ steps['fetchGitlabEntity'].output.entity.spec.url }}?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
+        repoUrl: gitlab.consulting.redhat.com?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
         defaultBranch: ${{ parameters.gitlabBranch | main }}
 
     #################################

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -29,37 +29,59 @@ spec:
       ui:group: argocd
       required:
         - argoInstance
-        - gitlabInstance
       properties:
         argoInstance:
           title: ArgoCD Instance
+          description: The ArgoCD instance that will manage this application. Choose from available instances.
+          enum:
+            - main
           type: string
-          description: The ArgoCD instance that will manage this application
-          ui:field: EntityPicker
-          ui:options:
-            catalogFilter:
-              - kind: System
-                spec.type: argocd
+
+    - title: GitLab Repository Information
+      required:
+        - gitlabInstance
+        - gitlabOwner
+        - gitlabRepository
+        - gitlabBranch
+      properties:
         gitlabInstance:
           title: GitLab Instance
           type: string
-          description: The GitLab instance to create a self-service repository in
-          ui:field: EntityPicker
-          ui:options:
-            catalogFilter:
-              - kind: System
-                spec.type: gitlab
+          description: GitLab instance
+          default: gitlab.com
         gitlabOwner:
           title: GitLab Owner
           type: string
           default: self-provisioned
-          description: The GitLab repository owner
+          description: GitLab repository owner
         gitlabRepository:
           title: GitLab Repository
           type: string
           default: manifests
-          description: The GitLab self-service repository
+          description: GitLab self-service repository
+        gitlabBranch:
+          title: GitLab Branch
+          type: string
+          default: main
+          description: GitLab repository branch
+
   steps:
+
+    #######################
+    ## Request Dynamic Data
+    #######################
+    - id: requestDynamicData
+      name: "Fetch Dynamic Data"
+      action: http:backstage:request
+      input:
+        method: 'POST'
+        path: 'proxy/data/fetch'
+        headers:
+          Content-Type: 'application/json'
+        body: |
+          {
+            "request": ["DOMAIN"]
+          }
 
     ##########################
     ## Template the Repository
@@ -76,7 +98,7 @@ spec:
           - projects
         values:
           targetRevision: "main"
-          domain: kechung.tamlab.rdu2.redhat.com #${{ parameters.argoInstance | parseEntityRef | pick('name') }}
+          domain: ${{ steps.requestDynamicData.output.body["DOMAIN"] }}
           path: "projects"
           projectName: "system"
 
@@ -88,13 +110,12 @@ spec:
       action: publish:gitlab
       input:
         allowedHosts:
-          - ${{ parameters.gitlabInstance | parseEntityRef | pick('name') }}
+          - ${{ parameters.gitlabInstance }}
         description: |
           Self-Service Repository
-        repoUrl: ${{ parameters.gitlabInstance | parseEntityRef | pick('name') }}?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
+        repoUrl: ${{ parameters.gitlabInstance }}?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
         #repoUrl: gitlab.consulting.redhat.com?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
-        #repoUrl: ${{ parameters.gitlabInstance | parseEntityRef }}?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
-        defaultBranch: main
+        defaultBranch: ${{ parameters.gitlabBranch | main }}
 
     #################################
     ## ArgoCD Resources Configuration
@@ -104,7 +125,7 @@ spec:
       action: argocd:create-resources
       input:
         appName: "root-self-service"
-        argoInstance: ${{ parameters.argoInstance | parseEntityRef | pick('name') }}
+        argoInstance: ${{ parameters.argoInstance }}
         namespace: "openshift-gitops"
         repoUrl: "${{ steps['publish'].output.remoteUrl }}.git"
         path: "_init_"
@@ -122,6 +143,6 @@ spec:
   output:
     links:
       - title: GitOps Application
-        url: ${{ parameters.argoInstance | parseEntityRef | pick('name') }}/applications/openshift-gitops/root-self-service
+        url: https://openshift-gitops-server-openshift-gitops.apps.${{ steps['requestDynamicData'].output.body["DOMAIN"] }}/applications/openshift-gitops/root-self-service
       - title: GitLab Repository
         url: ${{ steps['publish'].output.remoteUrl }}

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -76,17 +76,9 @@ spec:
           - projects
         values:
           targetRevision: "main"
-          domain: ${{ parameters.argoInstance.spec.domain | parseEntityRef }}
+          domain: kechung.tamlab.rdu2.redhat.com #${{ parameters.argoInstance | parseEntityRef | pick('name') }}
           path: "projects"
           projectName: "system"
-
-
-    - id: debug
-      name: Debug
-      action: debug:log
-      input:
-        message: ${{ parameters.gitlabInstance | ParseEntityRef }}
-
 
     #################################
     ## Create Self-Service Repository
@@ -96,10 +88,10 @@ spec:
       action: publish:gitlab
       input:
         allowedHosts:
-          - ${{ parameters.gitlabInstance.entity | parseEntityRef }}
+          - ${{ parameters.gitlabInstance | parseEntityRef | pick('name') }}
         description: |
           Self-Service Repository
-        repoUrl: ${{ parameters.gitlabInstance }}
+        repoUrl: ${{ parameters.gitlabInstance | parseEntityRef | pick('name') }}
         #repoUrl: gitlab.consulting.redhat.com?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
         #repoUrl: ${{ parameters.gitlabInstance | parseEntityRef }}?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
         defaultBranch: main
@@ -112,7 +104,7 @@ spec:
       action: argocd:create-resources
       input:
         appName: "root-self-service"
-        argoInstance: ${{ parameters.argoInstance | parseEntityRef }}
+        argoInstance: ${{ parameters.argoInstance | parseEntityRef | pick('name') }}
         namespace: "openshift-gitops"
         repoUrl: "${{ steps['publish'].output.remoteUrl }}.git"
         path: "_init_"
@@ -130,6 +122,6 @@ spec:
   output:
     links:
       - title: GitOps Application
-        url: ${{ parameters.argoInstance | parseEntityRef }}/applications/openshift-gitops/root-self-service
+        url: ${{ parameters.argoInstance | parseEntityRef | pick('name') }}/applications/openshift-gitops/root-self-service
       - title: GitLab Repository
         url: ${{ steps['publish'].output.remoteUrl }}

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -77,7 +77,6 @@ spec:
       input:
         entityRef: ${{ parameters.gitlabInstance }}
 
-
     - id: log-message
       name: Log Message
       action: debug:log
@@ -114,9 +113,9 @@ spec:
           - ${{ steps['fetchGitlabEntity'].output.entity.spec.url }}
         description: |
           Self-Service Repository
-        #repoUrl: ${{ steps['fetchGitlabEntity'].output.entity.spec.url }}?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
-        repoUrl: gitlab.consulting.redhat.com?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
-        defaultBranch: ${{ parameters.gitlabBranch | main }}
+        repoUrl: ${{ steps['fetchGitlabEntity'].output.entity.spec.url }}?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
+        #repoUrl: gitlab.consulting.redhat.com?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
+        defaultBranch: ${{ parameters.gitlabBranch }}
 
     #################################
     ## ArgoCD Resources Configuration

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -88,10 +88,7 @@ spec:
       name: Log2 Message
       action: debug:log
       input:
-        message: ${{ steps['fetchGitlabEntity'].output.entity.spec.domain.url | dump }}
-
-
-
+        message: ${{ steps['fetchGitlabEntity'].output.entity.spec.url | dump }}
 
     ##########################
     ## Template the Repository
@@ -120,10 +117,10 @@ spec:
       action: publish:gitlab
       input:
         allowedHosts:
-          - ${{ steps['fetchGitlabEntity'].output.entity.spec.domain.url | dump }}
+          - ${{ steps['fetchGitlabEntity'].output.entity.spec.url | 'gitlab.com' }}
         description: |
           Self-Service Repository
-        repoUrl: ${{ steps['fetchGitlabEntity'].output.entity.spec.domain.url | dump }}?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
+        repoUrl: ${{ steps['fetchGitlabEntity'].output.entity.spec.url | 'gitlab.com' }}?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
         #repoUrl: gitlab.consulting.redhat.com?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
         defaultBranch: ${{ parameters.gitlabBranch | main }}
 

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -85,7 +85,7 @@ spec:
       name: Debug
       action: debug:log
       input:
-        extra: ${{ parameters.gitlabInstance | ParseEntityRef }}
+        message: ${{ parameters.gitlabInstance | ParseEntityRef }}
 
 
     #################################

--- a/entities/catalog-info.yaml
+++ b/entities/catalog-info.yaml
@@ -1,24 +1,13 @@
 apiVersion: backstage.io/v1alpha1
-kind: System
+kind: Location
 metadata:
-  name: tamlab
-  description: ArgoCD
-  tags:
-    - argocd
+  namespace: default
+  name: resource-configs
+  annotations:
+    backstage.io/source-location: url:https://github.com/kevchu3/software-templates/blob/main/entities/catalog-info.yaml
+  description: Resource configurations
 spec:
-  type: argocd
-  url: openshift-gitops-server-openshift-gitops.apps.kechung.tamlab.rdu2.redhat.com
-  cluster: kechung.tamlab.rdu2.redhat.com
+  type: url
   owner: devops-team
----
-apiVersion: backstage.io/v1alpha1
-kind: System
-metadata:
-  name: gitlab.consulting.redhat.com
-  description: GitLab Consulting
-  tags:
-    - gitlab
-spec:
-  type: gitlab
-  url: gitlab.consulting.redhat.com
-  owner: devops-team
+  targets:
+    - resources.yaml

--- a/entities/catalog-info.yaml
+++ b/entities/catalog-info.yaml
@@ -7,7 +7,7 @@ metadata:
     - argocd
 spec:
   type: argocd
-  url: https://openshift-gitops-server-openshift-gitops.apps.kechung.tamlab.rdu2.redhat.com
+  url: openshift-gitops-server-openshift-gitops.apps.kechung.tamlab.rdu2.redhat.com
   cluster: kechung.tamlab.rdu2.redhat.com
   owner: devops-team
 ---
@@ -20,5 +20,5 @@ metadata:
     - gitlab
 spec:
   type: gitlab
-  url: https://gitlab.consulting.redhat.com
+  url: gitlab.consulting.redhat.com
   owner: devops-team

--- a/entities/catalog-info.yaml
+++ b/entities/catalog-info.yaml
@@ -1,7 +1,7 @@
 apiVersion: backstage.io/v1alpha1
 kind: System
 metadata:
-  name: openshift-gitops-server-openshift-gitops.apps.kechung.tamlab.rdu2.redhat.com
+  name: tamlab
   description: ArgoCD
   tags:
     - argocd

--- a/entities/catalog-info.yaml
+++ b/entities/catalog-info.yaml
@@ -1,8 +1,8 @@
 apiVersion: backstage.io/v1alpha1
 kind: System
 metadata:
-  name: tamlab
-  description: TAM Lab ArgoCD
+  name: openshift-gitops-server-openshift-gitops.apps.kechung.tamlab.rdu2.redhat.com
+  description: ArgoCD
   tags:
     - argocd
 spec:

--- a/entities/catalog-info.yaml
+++ b/entities/catalog-info.yaml
@@ -8,7 +8,8 @@ metadata:
 spec:
   type: argocd
   url: https://openshift-gitops-server-openshift-gitops.apps.kechung.tamlab.rdu2.redhat.com
-  domain: kechung.tamlab.rdu2.redhat.com
+  cluster: kechung.tamlab.rdu2.redhat.com
+  owner: devops-team
 ---
 apiVersion: backstage.io/v1alpha1
 kind: System
@@ -20,3 +21,4 @@ metadata:
 spec:
   type: gitlab
   url: https://gitlab.consulting.redhat.com
+  owner: devops-team

--- a/entities/catalog-info.yaml
+++ b/entities/catalog-info.yaml
@@ -1,0 +1,22 @@
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: tamlab
+  description: TAM Lab ArgoCD
+  tags:
+    - argocd
+spec:
+  type: argocd
+  url: https://openshift-gitops-server-openshift-gitops.apps.kechung.tamlab.rdu2.redhat.com
+  domain: kechung.tamlab.rdu2.redhat.com
+---
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: gitlab.consulting.redhat.com
+  description: GitLab Consulting
+  tags:
+    - gitlab
+spec:
+  type: gitlab
+  url: https://gitlab.consulting.redhat.com

--- a/entities/resources.yaml
+++ b/entities/resources.yaml
@@ -1,37 +1,25 @@
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
-  name: tamlab
-  description: TAM Lab ArgoCD
+  name: argocd
+  description: ArgoCD instance
   tags:
     - argocd
 spec:
   type: argocd
   instance: main
-  url: openshift-gitops-server-openshift-gitops.apps.kechung.tamlab.rdu2.redhat.com
-  cluster: kechung.tamlab.rdu2.redhat.com
+  url: openshift-gitops-server-openshift-gitops.apps.cluster.redhat.com
+  cluster: cluster.redhat.com
   owner: devops-team
 ---
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
-  name: gitlab-consulting
-  description: GitLab Consulting
+  name: gitlab
+  description: GitLab instance
   tags:
     - gitlab
 spec:
   type: gitlab
-  url: gitlab.consulting.redhat.com
-  owner: devops-team
----
-apiVersion: backstage.io/v1alpha1
-kind: Resource
-metadata:
-  name: gitlab-cee
-  description: GitLab CEE
-  tags:
-    - gitlab
-spec:
-  type: gitlab
-  url: gitlab.cee.redhat.com
+  url: gitlab.com
   owner: devops-team

--- a/entities/resources.yaml
+++ b/entities/resources.yaml
@@ -7,6 +7,7 @@ metadata:
     - argocd
 spec:
   type: argocd
+  instance: main
   url: openshift-gitops-server-openshift-gitops.apps.kechung.tamlab.rdu2.redhat.com
   cluster: kechung.tamlab.rdu2.redhat.com
   owner: devops-team

--- a/entities/resources.yaml
+++ b/entities/resources.yaml
@@ -2,7 +2,7 @@ apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
   name: tamlab
-  description: 
+  description: TAM Lab ArgoCD
   tags:
     - argocd
 spec:

--- a/entities/resources.yaml
+++ b/entities/resources.yaml
@@ -1,0 +1,24 @@
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: tamlab
+  description: 
+  tags:
+    - argocd
+spec:
+  type: argocd
+  url: openshift-gitops-server-openshift-gitops.apps.kechung.tamlab.rdu2.redhat.com
+  cluster: kechung.tamlab.rdu2.redhat.com
+  owner: devops-team
+---
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: gitlab
+  description: GitLab Consulting
+  tags:
+    - gitlab
+spec:
+  type: gitlab
+  url: gitlab.consulting.redhat.com
+  owner: devops-team

--- a/entities/resources.yaml
+++ b/entities/resources.yaml
@@ -15,11 +15,23 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
-  name: gitlab
+  name: gitlab-consulting
   description: GitLab Consulting
   tags:
     - gitlab
 spec:
   type: gitlab
   url: gitlab.consulting.redhat.com
+  owner: devops-team
+---
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: gitlab-cee
+  description: GitLab CEE
+  tags:
+    - gitlab
+spec:
+  type: gitlab
+  url: gitlab.cee.redhat.com
   owner: devops-team


### PR DESCRIPTION
Gitlab self-service repo Backstage template updates

I've implemented a few updates:
- Removed the `hacky http:backstage:request` implementation in favor of the following:
  - Template uses `EntityPicker` to populate ArgoCD and Gitlab instances
  - Generate those instances (see entities folder) one-time as an initial setup step (probably have to document this somewhere)
  - Implemented `catalog:fetch` to extract entity data (we overloaded fields under spec to store custom data)
- Ask some additional Gitlab repo configurations, populate defaults so user can skip through
- Enhancements to catalog item
  - Generate ArgoCD and Gitlab slugs on catalog-info.yaml
  - After successful task run, output direct link to catalog item