### PR TITLE
Fix sync-root-projects ArgoCD app

### DIFF
--- a/catalogs/argocd/setup-root-self-service-repository/skeleton/_init_/application.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/skeleton/_init_/application.yaml
@@ -5,12 +5,14 @@ metadata:
   namespace: "openshift-gitops"
   annotations:
     argocd.argoproj.io/sync-wave: "1"
+  labels:
+    backstage-name: root-self-service
 spec:
   destination:
     namespace: "openshift-gitops"
     server: 'https://kubernetes.default.svc'
   source:
-    repoURL: "https://gitlab.apps.${{ values.domain }}/self-provisioned/manifests.git"
+    repoURL: "https://${{ values.gitlabInstance }}/${{ values.gitlabProjectSlug }}.git"
     targetRevision: "${{ values.targetRevision }}"
     path: "${{ values.path }}"
     directory:

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -101,7 +101,7 @@ spec:
           targetRevision: "main"
           domain: ${{ steps['fetchArgoEntity'].output.entity.spec.cluster }}
           path: "projects"
-          projectName: "system"
+          projectName: "default"
           owner: user:${{ user.entity.metadata.namespace}}/${{ user.entity.metadata.name }}
           gitlabProjectSlug: ${{ parameters.gitlabOwner }}/${{ parameters.gitlabRepository }}
           gitlabInstance: ${{ steps['fetchGitlabEntity'].output.entity.spec.url }}

--- a/entities/catalog-info.yaml
+++ b/entities/catalog-info.yaml
@@ -3,8 +3,6 @@ kind: Location
 metadata:
   namespace: default
   name: resource-configs
-  annotations:
-    backstage.io/source-location: url:https://github.com/kevchu3/software-templates/blob/main/entities/catalog-info.yaml
   description: Resource configurations
 spec:
   type: url


### PR DESCRIPTION
Minor updates to sync-root-project ArgoCD application:
- Fix spec.source.repoUrl
- Add label to allow Backstage's gitlab project slug to pick it up
- Change app project name from system to default