### PR TITLE
Refactor entities into data science templates

### DIFF
--- a/catalogs/argocd/setup-root-self-service-repository/skeleton/_init_/application.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/skeleton/_init_/application.yaml
@@ -12,7 +12,7 @@ spec:
     namespace: "openshift-gitops"
     server: 'https://kubernetes.default.svc'
   source:
-    repoURL: "https://${{ values.gitlabInstance }}/${{ values.gitlabProjectSlug }}.git"
+    repoURL: "https://${{ values.gitlabInstance }}/${{ values.gitlabOwner }}/${{ values.gitlabRepository }}.git"
     targetRevision: "${{ values.targetRevision }}"
     path: "${{ values.path }}"
     directory:

--- a/catalogs/argocd/setup-root-self-service-repository/skeleton/_init_/application.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/skeleton/_init_/application.yaml
@@ -13,7 +13,7 @@ spec:
     server: 'https://kubernetes.default.svc'
   source:
     repoURL: "https://${{ values.gitlabInstance }}/${{ values.gitlabOwner }}/${{ values.gitlabRepository }}.git"
-    targetRevision: "${{ values.targetRevision }}"
+    targetRevision: "${{ values.gitlabBranch }}"
     path: "${{ values.path }}"
     directory:
       recurse: true

--- a/catalogs/argocd/setup-root-self-service-repository/skeleton/catalog-info.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/skeleton/catalog-info.yaml
@@ -10,9 +10,17 @@ metadata:
   annotations:
     argocd/app-selector: backstage-name=root-self-service
     backstage.io/techdocs-ref: dir:.
-    gitlab.com/project-slug: ${{ values.gitlabProjectSlug }}
+    gitlab.com/project-slug: ${{ values.gitlabOwner }}/${{ values.gitlabRepository }}
     gitlab.com/instance: ${{ values.gitlabInstance }}
 spec:
-  type: service
+  type: self-service
   lifecycle: production
   owner: ${{ values.owner }}
+  argocd:
+    cluster: ${{ values.argoCluster }}
+    url: ${{ values.argoUrl }}
+  gitlab:
+    instance: ${{ values.gitlabInstance }}
+    owner: ${{ values.gitlabOwner }}
+    repository: ${{ values.gitlabRepository }}
+    branch: ${{ values.gitlabBranch }}

--- a/catalogs/argocd/setup-root-self-service-repository/skeleton/catalog-info.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/skeleton/catalog-info.yaml
@@ -10,15 +10,10 @@ metadata:
   annotations:
     argocd/app-selector: backstage-name=root-self-service
     backstage.io/techdocs-ref: dir:.
-    gitlab.com/project-slug: ${{ values.gitlabOwner }}/${{ values.gitlabRepository }}
-    gitlab.com/instance: ${{ values.gitlabInstance }}
 spec:
   type: self-service
   lifecycle: production
   owner: ${{ values.owner }}
-  argocd:
-    cluster: ${{ values.argoCluster }}
-    url: ${{ values.argoUrl }}
   gitlab:
     instance: ${{ values.gitlabInstance }}
     owner: ${{ values.gitlabOwner }}

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -25,7 +25,7 @@ spec:
   type: Service
   parameters:
 
-    - title: ArgCD Application Information
+    - title: ArgoCD Application Information
       ui:group: argocd
       required:
         - argoInstance
@@ -74,6 +74,10 @@ spec:
 
   steps:
 
+    #################
+    ## Fetch Entities
+    #################
+
     - action: catalog:fetch
       id: fetchArgoEntity
       name: Fetch ArgoCD Entity
@@ -96,15 +100,19 @@ spec:
         copyWithoutTemplating:
           - README.md
           - LICENSE
+          - backstage
           - projects
         values:
-          targetRevision: "main"
-          domain: ${{ steps['fetchArgoEntity'].output.entity.spec.cluster }}
+          targetRevision: ${{ parameters.gitlabBranch }}
           path: "projects"
           projectName: "default"
           owner: user:${{ user.entity.metadata.namespace}}/${{ user.entity.metadata.name }}
-          gitlabProjectSlug: ${{ parameters.gitlabOwner }}/${{ parameters.gitlabRepository }}
+          argoCluster: ${{ steps['fetchArgoEntity'].output.entity.spec.cluster }}
+          argoUrl: ${{ steps['fetchArgoEntity'].output.entity.spec.url }}
           gitlabInstance: ${{ steps['fetchGitlabEntity'].output.entity.spec.url }}
+          gitlabOwner: ${{ parameters.gitlabOwner }}
+          gitlabRepository: ${{ parameters.gitlabRepository }}
+          gitlabBranch: ${{ parameters.gitlabBranch }}
 
     #################################
     ## Create Self-Service Repository

--- a/catalogs/argocd/setup-root-self-service-repository/template.yaml
+++ b/catalogs/argocd/setup-root-self-service-repository/template.yaml
@@ -25,21 +25,6 @@ spec:
   type: Service
   parameters:
 
-    - title: ArgoCD Application Information
-      ui:group: argocd
-      required:
-        - argoInstance
-      properties:
-        argoInstance:
-          title: ArgoCD Instance
-          type: string
-          description: The ArgoCD instance that will manage this application. Choose from available instances.
-          ui:field: EntityPicker
-          ui:options:
-            catalogFilter:
-              - kind: Resource
-                spec.type: argocd
-
     - title: GitLab Repository Information
       required:
         - gitlabInstance
@@ -50,12 +35,8 @@ spec:
         gitlabInstance:
           title: GitLab Instance
           type: string
+          default: gitlab.com
           description: GitLab instance
-          ui:field: EntityPicker
-          ui:options:
-            catalogFilter:
-              - kind: Resource
-                spec.type: gitlab
         gitlabOwner:
           title: GitLab Owner
           type: string
@@ -78,17 +59,6 @@ spec:
     ## Fetch Entities
     #################
 
-    - action: catalog:fetch
-      id: fetchArgoEntity
-      name: Fetch ArgoCD Entity
-      input:
-        entityRef: ${{ parameters.argoInstance }}
-    - action: catalog:fetch
-      id: fetchGitlabEntity
-      name: Fetch Gitlab Entity
-      input:
-        entityRef: ${{ parameters.gitlabInstance }}
-
     ##########################
     ## Template the Repository
     ##########################
@@ -103,13 +73,10 @@ spec:
           - backstage
           - projects
         values:
-          targetRevision: ${{ parameters.gitlabBranch }}
           path: "projects"
           projectName: "default"
           owner: user:${{ user.entity.metadata.namespace}}/${{ user.entity.metadata.name }}
-          argoCluster: ${{ steps['fetchArgoEntity'].output.entity.spec.cluster }}
-          argoUrl: ${{ steps['fetchArgoEntity'].output.entity.spec.url }}
-          gitlabInstance: ${{ steps['fetchGitlabEntity'].output.entity.spec.url }}
+          gitlabInstance: ${{ parameters.gitlabInstance }}
           gitlabOwner: ${{ parameters.gitlabOwner }}
           gitlabRepository: ${{ parameters.gitlabRepository }}
           gitlabBranch: ${{ parameters.gitlabBranch }}
@@ -122,10 +89,10 @@ spec:
       action: publish:gitlab
       input:
         allowedHosts:
-          - ${{ steps['fetchGitlabEntity'].output.entity.spec.url }}
+          - ${{ parameters.gitlabInstance }}
         description: |
           Self-Service Repository
-        repoUrl: ${{ steps['fetchGitlabEntity'].output.entity.spec.url }}?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
+        repoUrl: ${{ parameters.gitlabInstance }}?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
         defaultBranch: ${{ parameters.gitlabBranch }}
         settings:
           visibility: "public"
@@ -138,7 +105,7 @@ spec:
       action: argocd:create-resources
       input:
         appName: "root-self-service"
-        argoInstance: ${{ steps['fetchArgoEntity'].output.entity.spec.instance }}
+        argoInstance: main
         namespace: "openshift-gitops"
         repoUrl: "${{ steps['publish'].output.remoteUrl }}.git"
         path: "_init_"
@@ -155,8 +122,6 @@ spec:
 
   output:
     links:
-      - title: GitOps Application
-        url: https://${{ steps['fetchArgoEntity'].output.entity.spec.url }}/applications/openshift-gitops/root-self-service
       - title: GitLab Repository
         url: ${{ steps['publish'].output.remoteUrl }}
       - title: Open in catalog

--- a/catalogs/openshift-ai/datascience/data-connector/template.yaml
+++ b/catalogs/openshift-ai/datascience/data-connector/template.yaml
@@ -28,7 +28,7 @@ spec:
       ui:group: data-connector
       required:
         - rootSelfServiceRepo
-        - projectName
+        - projectEntity
         - dataConnectorName
         - bucketName
         - defaultRegion
@@ -42,7 +42,7 @@ spec:
             catalogFilter:
               - kind: Component
                 spec.type: self-service
-        projectName:
+        projectEntity:
           title: Project Name
           type: string
           description: The project where the data connector is integrated.
@@ -94,15 +94,18 @@ spec:
       action: fetch:template
       input:
         url: "../../../../skeletons/applications/helm/"
-        targetPath: "projects/${{ parameters.projectName | parseEntityRef | pick('name') }}/"
+        targetPath: "projects/${{ parameters.projectEntity | parseEntityRef | pick('name') }}/"
         values:
           repoName: "${{ parameters.dataConnectorName }}-dc"
-          namespace: "${{ parameters.projectName | parseEntityRef | pick('name') }}"
+          namespace: "${{ parameters.projectEntity | parseEntityRef | pick('name') }}"
+          labels:
+            project: ${{ parameters.projectEntity | parseEntityRef | pick('name') }}
+            data-connector: ${{ parameters.dataConnectorName }}
           chart:
             name: "data-connector"
             chartUrl: "https://poc-examples.github.io/supporting-charts"
             chartVersion: "0.1.2"
-          projectName: "${{ parameters.projectName | parseEntityRef | pick('name') }}"
+          projectName: "${{ parameters.projectEntity | parseEntityRef | pick('name') }}"
           automated:
             prune: true
             selfHeal: true
@@ -121,11 +124,12 @@ spec:
       action: fetch:template
       input:
         url: "../../../../skeletons/backstage/data-connector"
-        targetPath: "backstage/${{ parameters.projectName | parseEntityRef | pick('name') }}/"
+        targetPath: "backstage/${{ parameters.projectEntity | parseEntityRef | pick('name') }}/"
         values:
+          projectName: ${{ parameters.projectEntity | parseEntityRef | pick('name') }}
           name: ${{ parameters.dataConnectorName }}
           owner: user:${{ user.entity.metadata.namespace}}/${{ user.entity.metadata.name }}
-          subcomponentOf: ${{ parameters.projectName }}
+          subcomponentOf: ${{ parameters.projectEntity }}
           dependsOn: ${{ parameters.rootSelfServiceRepo }}
 
     ##############
@@ -136,16 +140,16 @@ spec:
       action: fs:rename
       input:
         files:
-          - from: "projects/${{ parameters.projectName | parseEntityRef | pick('name') }}/application.yaml"
-            to: "projects/${{ parameters.projectName | parseEntityRef | pick('name') }}/${{ parameters.dataConnectorName }}-data-connector.yaml"
+          - from: "projects/${{ parameters.projectEntity | parseEntityRef | pick('name') }}/application.yaml"
+            to: "projects/${{ parameters.projectEntity | parseEntityRef | pick('name') }}/${{ parameters.dataConnectorName }}-data-connector.yaml"
 
     - id: changeBackstageTemplateName
       name: Change Backstage Template Name
       action: fs:rename
       input:
         files:
-          - from: "backstage/${{ parameters.projectName | parseEntityRef | pick('name') }}/data-connector.yaml"
-            to: "backstage/${{ parameters.projectName | parseEntityRef | pick('name') }}/${{ parameters.dataConnectorName }}-data-connector.yaml"
+          - from: "backstage/${{ parameters.projectEntity | parseEntityRef | pick('name') }}/data-connector.yaml"
+            to: "backstage/${{ parameters.projectEntity | parseEntityRef | pick('name') }}/${{ parameters.dataConnectorName }}-data-connector.yaml"
 
     ##########################
     ## Push Repository Changes
@@ -171,7 +175,7 @@ spec:
       action: catalog:register
       input:
         repoContentsUrl: https://${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.instance }}/${{ steps["publishManifests"].output.projectPath }}
-        catalogInfoPath: /-/blob/${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.branch }}/backstage/${{ parameters.projectName | parseEntityRef | pick('name') }}/${{ parameters.dataConnectorName}}-data-connector.yaml
+        catalogInfoPath: /-/blob/${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.branch }}/backstage/${{ parameters.projectEntity | parseEntityRef | pick('name') }}/${{ parameters.dataConnectorName}}-data-connector.yaml
 
   output:
     links:

--- a/catalogs/openshift-ai/datascience/data-connector/template.yaml
+++ b/catalogs/openshift-ai/datascience/data-connector/template.yaml
@@ -100,7 +100,7 @@ spec:
           namespace: "${{ parameters.projectEntity | parseEntityRef | pick('name') }}"
           labels:
             project: ${{ parameters.projectEntity | parseEntityRef | pick('name') }}
-            data-connector: ${{ parameters.dataConnectorName }}
+            dataConnector: ${{ parameters.dataConnectorName }}
           chart:
             name: "data-connector"
             chartUrl: "https://poc-examples.github.io/supporting-charts"
@@ -179,8 +179,6 @@ spec:
 
   output:
     links:
-      - title: GitOps Application
-        url: https://${{ steps['fetchSelfServiceEntity'].output.entity.spec.argocd.url }}/applications/openshift-gitops/root-self-service
       - title: GitLab Repository
         url: https://${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.instance }}/${{ steps['publishManifests'].output.projectPath }}
       - title: Open in catalog

--- a/catalogs/openshift-ai/datascience/data-connector/template.yaml
+++ b/catalogs/openshift-ai/datascience/data-connector/template.yaml
@@ -15,6 +15,7 @@ metadata:
     - automation
     - data-science
     - data-pipelines
+    - gitlab
     - argocd
 
 spec:
@@ -23,36 +24,36 @@ spec:
   type: Data-Connector
   parameters:
 
-    - title: ArgoCD Selection
-      ui:group: argocd
-      required:
-        - argoInstance
-      properties:
-        argoInstance:
-          title: ArgoCD Instance
-          description: The ArgoCD instance that will manage this application. Choose from available instances.
-          enum:
-            - main
-          type: string
-
     - title: Data Connector Settings
       ui:group: data-connector
       required:
-        - dataConnectorName
+        - rootSelfServiceRepo
         - projectName
+        - dataConnectorName
         - bucketName
         - defaultRegion
       properties:
+        rootSelfServiceRepo:
+          title: Root Self-Service Repository
+          type: string
+          description: The root self-service repository that contains artifact deployment configurations.
+          ui:field: EntityPicker
+          ui:options:
+            catalogFilter:
+              - kind: Component
+                spec.type: self-service
+        projectName:
+          title: Project Name
+          type: string
+          description: The project where the data connector is integrated.
+          ui:field: EntityPicker
+          ui:options:
+            catalogFilter:
+              - kind: Component
+                spec.type: data-science-project
         dataConnectorName:
           title: Data Connector Name
           description: The name of the data connector.
-          type: string
-          pattern: "^[a-z][a-z0-9-]+$"
-          minLength: 3
-          maxLength: 30
-        projectName:
-          title: Project Name
-          description: The project where the data connector is integrated.
           type: string
           pattern: "^[a-z][a-z0-9-]+$"
           minLength: 3
@@ -75,21 +76,15 @@ spec:
 
   steps:
 
-    #######################
-    ## Request Dynamic Data
-    #######################
-    - id: requestDynamicData
-      name: Fetch Dynamic Data
-      action: http:backstage:request
+    #################
+    ## Fetch Entities
+    #################
+
+    - action: catalog:fetch
+      id: fetchSelfServiceEntity
+      name: Fetch Root Self-Service Repo Entity
       input:
-        method: 'POST'
-        path: 'proxy/data/fetch'
-        headers:
-          Content-Type: 'application/json'
-        body: |
-          {
-            "request": ["DOMAIN"]
-          }
+        entityRef: ${{ parameters.rootSelfServiceRepo }}
 
     ###########################
     ## Template the Application
@@ -99,15 +94,15 @@ spec:
       action: fetch:template
       input:
         url: "../../../../skeletons/applications/helm/"
-        targetPath: "projects/${{ parameters.projectName }}/"
+        targetPath: "projects/${{ parameters.projectName | parseEntityRef | pick('name') }}/"
         values:
           repoName: "${{ parameters.dataConnectorName }}-dc"
-          namespace: "${{ parameters.projectName }}"
+          namespace: "${{ parameters.projectName | parseEntityRef | pick('name') }}"
           chart:
             name: "data-connector"
             chartUrl: "https://poc-examples.github.io/supporting-charts"
             chartVersion: "0.1.2"
-          projectName: "${{ parameters.projectName }}"
+          projectName: "${{ parameters.projectName | parseEntityRef | pick('name') }}"
           automated:
             prune: true
             selfHeal: true
@@ -121,16 +116,36 @@ spec:
                 bucketName: ${{ parameters.bucketName }}
               secretRef: aws-credentials
 
+    - id: templateDataConnectorEntity
+      name: Template Data Connector Entity
+      action: fetch:template
+      input:
+        url: "../../../../skeletons/backstage/data-connector"
+        targetPath: "backstage/${{ parameters.projectName | parseEntityRef | pick('name') }}/"
+        values:
+          name: ${{ parameters.dataConnectorName }}
+          owner: user:${{ user.entity.metadata.namespace}}/${{ user.entity.metadata.name }}
+          subcomponentOf: ${{ parameters.projectName }}
+          dependsOn: ${{ parameters.rootSelfServiceRepo }}
+
     ##############
     ## Rename File
     ##############
-    - id: changeTemplateName
-      name: Change Template Name
+    - id: changeProjectTemplateName
+      name: Change ProjectTemplate Name
       action: fs:rename
       input:
         files:
-          - from: "projects/${{ parameters.projectName }}/application.yaml"
-            to: "projects/${{ parameters.projectName }}/${{ parameters.dataConnectorName }}-data-connector.yaml"
+          - from: "projects/${{ parameters.projectName | parseEntityRef | pick('name') }}/application.yaml"
+            to: "projects/${{ parameters.projectName | parseEntityRef | pick('name') }}/${{ parameters.dataConnectorName }}-data-connector.yaml"
+
+    - id: changeBackstageTemplateName
+      name: Change Backstage Template Name
+      action: fs:rename
+      input:
+        files:
+          - from: "backstage/${{ parameters.projectName | parseEntityRef | pick('name') }}/data-connector.yaml"
+            to: "backstage/${{ parameters.projectName | parseEntityRef | pick('name') }}/${{ parameters.dataConnectorName }}-data-connector.yaml"
 
     ##########################
     ## Push Repository Changes
@@ -140,19 +155,30 @@ spec:
       action: gitlab:repo:push
       input:
         allowedHosts:
-          - 'gitlab.com'
+          - ${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.instance }}
         description: |
           placeholder
-        repoUrl: gitlab.com?owner=self-provisioned&repo=manifests
-        sourcePath: "./projects/${{ parameters.projectName }}"
-        targetPath: "./projects/${{ parameters.projectName }}"
-        branchName: main
+        repoUrl: ${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.instance }}?owner=${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.owner }}&repo=${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.repository }}
+        branchName: ${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.branch }}
         commitAction: create
         commitMessage: "Created ${{ parameters.dataConnectorName }} Data Connector"
+
+    ########################
+    ## Register Catalog Info
+    ########################
+    - id: registerCatalog
+      name: "Register Catalog Info"
+      action: catalog:register
+      input:
+        repoContentsUrl: https://${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.instance }}/${{ steps["publishManifests"].output.projectPath }}
+        catalogInfoPath: /-/blob/${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.branch }}/backstage/${{ parameters.projectName | parseEntityRef | pick('name') }}/${{ parameters.dataConnectorName}}-data-connector.yaml
 
   output:
     links:
       - title: GitOps Application
-        url: https://openshift-gitops-server-openshift-gitops.apps.${{ steps['requestDynamicData'].output.body["DOMAIN"] }}/applications/openshift-gitops/root-self-service
+        url: https://${{ steps['fetchSelfServiceEntity'].output.entity.spec.argocd.url }}/applications/openshift-gitops/root-self-service
       - title: GitLab Repository
-        url: https://gitlab.apps.${{ steps['requestDynamicData'].output.body["DOMAIN"] }}/self-provisioned/manifests.git
+        url: https://${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.instance }}/${{ steps['publishManifests'].output.projectPath }}
+      - title: Open in catalog
+        icon: catalog
+        entityRef: ${{ steps['registerCatalog'].output.entityRef }}

--- a/catalogs/openshift-ai/datascience/project/template.yaml
+++ b/catalogs/openshift-ai/datascience/project/template.yaml
@@ -69,6 +69,8 @@ spec:
         values:
           repoName: "${{ parameters.projectName }}-ds-project"
           namespace: "openshift-gitops"
+          labels:
+            project: ${{ parameters.projectName }}
           syncWave: "-1"
           chart:
             name: "data-science-project"

--- a/catalogs/openshift-ai/datascience/project/template.yaml
+++ b/catalogs/openshift-ai/datascience/project/template.yaml
@@ -14,6 +14,7 @@ metadata:
     - automation
     - data-science
     - data-pipelines
+    - gitlab
     - argocd
 
 spec:
@@ -21,27 +22,21 @@ spec:
   system: self-service
   type: DataScience-Project
   parameters:
-
-    - title: ArgoCD Selection
-      ui:group: argocd
-      required:
-        - argoInstance
-      properties:
-        argoInstance:
-          title: ArgoCD Instance
-          type: string
-          description: The ArgoCD instance that will manage this application. Choose from available instances.
-          ui:field: EntityPicker
-          ui:options:
-            catalogFilter:
-              - kind: Resource
-                spec.type: argocd
-
     - title: DataScience Project Settings
       ui:group: data-project
       required:
+        - rootSelfServiceRepo
         - projectName
       properties:
+        rootSelfServiceRepo:
+          title: Root Self-Service Repository
+          type: string
+          description: The root self-service repository that contains artifact deployment configurations.
+          ui:field: EntityPicker
+          ui:options:
+            catalogFilter:
+              - kind: Component
+                spec.type: self-service
         projectName:
           title: Project Name
           description: The project where the data connector is integrated.
@@ -50,50 +45,17 @@ spec:
           minLength: 3
           maxLength: 30
 
-    - title: GitLab Repository Information
-      required:
-        - gitlabInstance
-        - gitlabOwner
-        - gitlabRepository
-        - gitlabBranch
-      properties:
-        gitlabInstance:
-          title: GitLab Instance
-          type: string
-          description: GitLab instance
-          ui:field: EntityPicker
-          ui:options:
-            catalogFilter:
-              - kind: Resource
-                spec.type: gitlab
-        gitlabOwner:
-          title: GitLab Owner
-          type: string
-          default: self-provisioned
-          description: GitLab repository owner
-        gitlabRepository:
-          title: GitLab Repository
-          type: string
-          default: manifests
-          description: GitLab self-service repository
-        gitlabBranch:
-          title: GitLab Branch
-          type: string
-          default: main
-          description: GitLab repository branch
-
   steps:
 
+    #################
+    ## Fetch Entities
+    #################
+
     - action: catalog:fetch
-      id: fetchArgoEntity
-      name: Fetch ArgoCD Entity
+      id: fetchSelfServiceEntity
+      name: Fetch Root Self-Service Repo Entity
       input:
-        entityRef: ${{ parameters.argoInstance }}
-    - action: catalog:fetch
-      id: fetchGitlabEntity
-      name: Fetch Gitlab Entity
-      input:
-        entityRef: ${{ parameters.gitlabInstance }}
+        entityRef: ${{ parameters.rootSelfServiceRepo }}
 
     ###########################
     ## Template the Application
@@ -119,17 +81,36 @@ spec:
           createNamespace: "false"
           valuesObject: |
             project: ${{ parameters.projectName }}
+        
+    - id: templateProjectEntity
+      name: Template Project Entity
+      action: fetch:template
+      input:
+        url: "../../../../skeletons/backstage/data-science-project"
+        targetPath: "backstage/${{ parameters.projectName }}/"
+        values:
+          name: ${{ parameters.projectName }}
+          owner: user:${{ user.entity.metadata.namespace}}/${{ user.entity.metadata.name }}
+          dependsOn: ${{ parameters.rootSelfServiceRepo }}
 
     ##############
     ## Rename File
     ##############
-    - id: changeTemplateName
-      name: Change Template Name
+    - id: changeProjectTemplateName
+      name: Change Project Template Name
       action: fs:rename
       input:
         files:
           - from: "projects/${{ parameters.projectName }}/application.yaml"
             to: "projects/${{ parameters.projectName }}/${{ parameters.projectName }}-ds-project.yaml"
+
+    - id: changeBackstageTemplateName
+      name: Change Backstage Template Name
+      action: fs:rename
+      input:
+        files:
+          - from: "backstage/${{ parameters.projectName }}/data-science-project.yaml"
+            to: "backstage/${{ parameters.projectName }}/${{ parameters.projectName }}-ds-project.yaml"
 
     ##########################
     ## Push Repository Changes
@@ -139,19 +120,30 @@ spec:
       action: gitlab:repo:push
       input:
         allowedHosts:
-          - ${{ steps['fetchGitlabEntity'].output.entity.spec.url }}
+          - ${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.instance }}
         description: |
           placeholder
-        repoUrl: ${{ steps['fetchGitlabEntity'].output.entity.spec.url }}?owner=${{ parameters.gitlabOwner }}&repo=${{ parameters.gitlabRepository }}
-        sourcePath: "./projects/${{ parameters.projectName }}"
-        targetPath: "./projects/${{ parameters.projectName }}"
-        branchName: ${{ parameters.gitlabBranch }}
+        repoUrl: ${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.instance }}?owner=${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.owner }}&repo=${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.repository }}
+        branchName: ${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.branch }}
         commitAction: create
         commitMessage: "Created ${{ parameters.projectName }} Data Science Project"
+
+    ########################
+    ## Register Catalog Info
+    ########################
+    - id: registerCatalog
+      name: "Register Catalog Info"
+      action: catalog:register
+      input:
+        repoContentsUrl: https://${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.instance }}/${{ steps["publishManifests"].output.projectPath }}
+        catalogInfoPath: /-/blob/${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.branch }}/backstage/${{ parameters.projectName }}/${{ parameters.projectName }}-ds-project.yaml
 
   output:
     links:
       - title: GitOps Application
-        url: https://${{ steps['fetchArgoEntity'].output.entity.spec.url }}/applications/openshift-gitops/root-self-service
+        url: https://${{ steps['fetchSelfServiceEntity'].output.entity.spec.argocd.url }}/applications/openshift-gitops/root-self-service
       - title: GitLab Repository
-        url: https://${{ steps['fetchGitlabEntity'].output.entity.spec.url }}/${{ steps['publishManifests'].output.projectPath }}
+        url: https://${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.instance }}/${{ steps['publishManifests'].output.projectPath }}
+      - title: Open in catalog
+        icon: catalog
+        entityRef: ${{ steps['registerCatalog'].output.entityRef }}

--- a/catalogs/openshift-ai/datascience/project/template.yaml
+++ b/catalogs/openshift-ai/datascience/project/template.yaml
@@ -23,7 +23,7 @@ spec:
   type: DataScience-Project
   parameters:
     - title: DataScience Project Settings
-      ui:group: data-project
+      ui:group: data-science-project
       required:
         - rootSelfServiceRepo
         - projectName

--- a/catalogs/openshift-ai/datascience/project/template.yaml
+++ b/catalogs/openshift-ai/datascience/project/template.yaml
@@ -142,8 +142,6 @@ spec:
 
   output:
     links:
-      - title: GitOps Application
-        url: https://${{ steps['fetchSelfServiceEntity'].output.entity.spec.argocd.url }}/applications/openshift-gitops/root-self-service
       - title: GitLab Repository
         url: https://${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.instance }}/${{ steps['publishManifests'].output.projectPath }}
       - title: Open in catalog

--- a/catalogs/openshift-ai/datascience/single-model-server/template.yaml
+++ b/catalogs/openshift-ai/datascience/single-model-server/template.yaml
@@ -16,6 +16,7 @@ metadata:
     - automation
     - ai-workloads
     - mlops
+    - gitlab
     - argocd
 
 spec:
@@ -86,11 +87,13 @@ spec:
       properties:
         dataConnectorName:
           title: Data Connector Name
-          description: The name of the data connector.
           type: string
-          pattern: "^[a-z][a-z0-9-]+$"
-          minLength: 3
-          maxLength: 30
+          description: The name of the data connector.
+          ui:field: EntityPicker
+          ui:options:
+            catalogFilter:
+              - kind: Component
+                spec.type: data-connector
         modelPath:
           title: Model Path
           description: The path to the Model in Data Connector.
@@ -112,19 +115,19 @@ spec:
     ## Template the Application
     ###########################
     - id: applicationTemplate
-      name: Template Helm Application:template
+      name: Template Helm Application
       action: fetch:template
       input:
         url: "../../../../skeletons/applications/helm/"
-        targetPath: "projects/${{ parameters.projectName }}/"
+        targetPath: "projects/${{ parameters.projectName | parseEntityRef | pick('name') }}/"
         values:
           repoName: "${{ parameters.modelName }}-model-server"
-          namespace: "${{ parameters.projectName }}"
+          namespace: "${{ parameters.projectName | parseEntityRef | pick('name') }}"
           chart:
             name: "data-single-model-server"
             chartUrl: "https://poc-examples.github.io/supporting-charts"
             chartVersion: "0.1.1"
-          projectName: "${{ parameters.projectName }}"
+          projectName: "${{ parameters.projectName | parseEntityRef | pick('name') }}"
           automated:
             prune: true
             selfHeal: true
@@ -135,11 +138,23 @@ spec:
             replicas: 1
             GPUCount: ${{ parameters.numGPU }}
             dataConnection:
-              name: ${{ parameters.dataConnectorName }}
+              name: ${{ parameters.dataConnectorName | parseEntityRef | pick('name') }}
               modelPath: ${{ parameters.modelPath }}
             resources:
               cpu: "${{ parameters.cpuLimit }}"
               mem: "${{ parameters.memoryLimit }}"
+
+    - id: templateModelServerEntity
+      name: Template Model Server Entity
+      action: fetch:template
+      input:
+        url: "../../../../skeletons/backstage/model-server"
+        targetPath: "backstage/${{ parameters.projectName | parseEntityRef | pick('name') }}/"
+        values:
+          name: ${{ parameters.modelName }}
+          owner: user:${{ user.entity.metadata.namespace}}/${{ user.entity.metadata.name }}
+          subcomponentOf: ${{ parameters.projectName }}
+          dependsOn: ${{ parameters.rootSelfServiceRepo }}
 
     ##############
     ## Rename File
@@ -149,8 +164,16 @@ spec:
       action: fs:rename
       input:
         files:
-          - from: "projects/${{ parameters.projectName }}/application.yaml"
-            to: "projects/${{ parameters.projectName }}/${{ parameters.modelName }}-model-server.yaml"
+          - from: "projects/${{ parameters.projectName | parseEntityRef | pick('name') }}/application.yaml"
+            to: "projects/${{ parameters.projectName | parseEntityRef | pick('name') }}/${{ parameters.modelName }}-model-server.yaml"
+
+    - id: changeBackstageTemplateName
+      name: Change Backstage Template Name
+      action: fs:rename
+      input:
+        files:
+          - from: "backstage/${{ parameters.projectName | parseEntityRef | pick('name') }}/model-server.yaml"
+            to: "backstage/${{ parameters.projectName | parseEntityRef | pick('name') }}/${{ parameters.modelName }}-model-server.yaml"
 
     ##########################
     ## Push Repository Changes
@@ -160,13 +183,11 @@ spec:
       action: gitlab:repo:push
       input:
         allowedHosts:
-          - 'gitlab.com'
+          - ${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.instance }}
         description: |
           placeholder
-        repoUrl: gitlab.com?owner=self-provisioned&repo=manifests
-        sourcePath: "./projects/${{ parameters.projectName }}"
-        targetPath: "./projects/${{ parameters.projectName }}"
-        branchName: main
+        repoUrl: ${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.instance }}?owner=${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.owner }}&repo=${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.repository }}
+        branchName: ${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.branch }}
         commitAction: create
         commitMessage: "Created ${{ parameters.modelName }} Model Server"
 
@@ -177,8 +198,8 @@ spec:
       name: "Register Catalog Info"
       action: catalog:register
       input:
-        repoContentsUrl: ${{ steps["publishManifests"].output.repoContentsUrl }}
-        catalogInfoPath: /model-server-entity.yaml
+        repoContentsUrl: https://${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.instance }}/${{ steps["publishManifests"].output.projectPath }}
+        catalogInfoPath: /-/blob/${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.branch }}/backstage/${{ parameters.projectName | parseEntityRef | pick('name') }}/${{ parameters.modelName}}-model-server.yaml
 
   output:
     links:
@@ -186,3 +207,6 @@ spec:
         url: https://${{ steps['fetchSelfServiceEntity'].output.entity.spec.argocd.url }}/applications/openshift-gitops/root-self-service
       - title: GitLab Repository
         url: https://${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.instance }}/${{ steps['publishManifests'].output.projectPath }}
+      - title: Open in catalog
+        icon: catalog
+        entityRef: ${{ steps['registerCatalog'].output.entityRef }}

--- a/catalogs/openshift-ai/datascience/single-model-server/template.yaml
+++ b/catalogs/openshift-ai/datascience/single-model-server/template.yaml
@@ -29,7 +29,7 @@ spec:
       ui:group: data-model-serving
       required:
         - rootSelfServiceRepo
-        - projectName
+        - projectEntity
         - modelName
       properties:
         rootSelfServiceRepo:
@@ -41,7 +41,7 @@ spec:
             catalogFilter:
               - kind: Component
                 spec.type: self-service
-        projectName:
+        projectEntity:
           title: Project Name
           type: string
           description: The project where the data connector is integrated.
@@ -82,10 +82,10 @@ spec:
     - title: Model Serving Settings
       ui:group: data-model-serving
       required:
-        - dataConnectorName
+        - dataConnectorEntity
         - modelPath
       properties:
-        dataConnectorName:
+        dataConnectorEntity:
           title: Data Connector Name
           type: string
           description: The name of the data connector.
@@ -119,15 +119,18 @@ spec:
       action: fetch:template
       input:
         url: "../../../../skeletons/applications/helm/"
-        targetPath: "projects/${{ parameters.projectName | parseEntityRef | pick('name') }}/"
+        targetPath: "projects/${{ parameters.projectEntity | parseEntityRef | pick('name') }}/"
         values:
           repoName: "${{ parameters.modelName }}-model-server"
-          namespace: "${{ parameters.projectName | parseEntityRef | pick('name') }}"
+          namespace: "${{ parameters.projectEntity | parseEntityRef | pick('name') }}"
+          labels:
+            project: ${{ parameters.projectEntity | parseEntityRef | pick('name') }}
+            model-server: ${{ parameters.modelName }}
           chart:
             name: "data-single-model-server"
             chartUrl: "https://poc-examples.github.io/supporting-charts"
             chartVersion: "0.1.1"
-          projectName: "${{ parameters.projectName | parseEntityRef | pick('name') }}"
+          projectName: "${{ parameters.projectEntity | parseEntityRef | pick('name') }}"
           automated:
             prune: true
             selfHeal: true
@@ -138,7 +141,7 @@ spec:
             replicas: 1
             GPUCount: ${{ parameters.numGPU }}
             dataConnection:
-              name: ${{ parameters.dataConnectorName | parseEntityRef | pick('name') }}
+              name: ${{ parameters.dataConnectorEntity | parseEntityRef | pick('name') }}
               modelPath: ${{ parameters.modelPath }}
             resources:
               cpu: "${{ parameters.cpuLimit }}"
@@ -149,11 +152,12 @@ spec:
       action: fetch:template
       input:
         url: "../../../../skeletons/backstage/model-server"
-        targetPath: "backstage/${{ parameters.projectName | parseEntityRef | pick('name') }}/"
+        targetPath: "backstage/${{ parameters.projectEntity | parseEntityRef | pick('name') }}/"
         values:
+          projectName: ${{ parameters.projectEntity | parseEntityRef | pick('name') }}
           name: ${{ parameters.modelName }}
           owner: user:${{ user.entity.metadata.namespace}}/${{ user.entity.metadata.name }}
-          subcomponentOf: ${{ parameters.projectName }}
+          subcomponentOf: ${{ parameters.projectEntity }}
           dependsOn: ${{ parameters.rootSelfServiceRepo }}
 
     ##############
@@ -164,16 +168,16 @@ spec:
       action: fs:rename
       input:
         files:
-          - from: "projects/${{ parameters.projectName | parseEntityRef | pick('name') }}/application.yaml"
-            to: "projects/${{ parameters.projectName | parseEntityRef | pick('name') }}/${{ parameters.modelName }}-model-server.yaml"
+          - from: "projects/${{ parameters.projectEntity | parseEntityRef | pick('name') }}/application.yaml"
+            to: "projects/${{ parameters.projectEntity | parseEntityRef | pick('name') }}/${{ parameters.modelName }}-model-server.yaml"
 
     - id: changeBackstageTemplateName
       name: Change Backstage Template Name
       action: fs:rename
       input:
         files:
-          - from: "backstage/${{ parameters.projectName | parseEntityRef | pick('name') }}/model-server.yaml"
-            to: "backstage/${{ parameters.projectName | parseEntityRef | pick('name') }}/${{ parameters.modelName }}-model-server.yaml"
+          - from: "backstage/${{ parameters.projectEntity | parseEntityRef | pick('name') }}/model-server.yaml"
+            to: "backstage/${{ parameters.projectEntity | parseEntityRef | pick('name') }}/${{ parameters.modelName }}-model-server.yaml"
 
     ##########################
     ## Push Repository Changes
@@ -199,7 +203,7 @@ spec:
       action: catalog:register
       input:
         repoContentsUrl: https://${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.instance }}/${{ steps["publishManifests"].output.projectPath }}
-        catalogInfoPath: /-/blob/${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.branch }}/backstage/${{ parameters.projectName | parseEntityRef | pick('name') }}/${{ parameters.modelName}}-model-server.yaml
+        catalogInfoPath: /-/blob/${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.branch }}/backstage/${{ parameters.projectEntity | parseEntityRef | pick('name') }}/${{ parameters.modelName}}-model-server.yaml
 
   output:
     links:

--- a/catalogs/openshift-ai/datascience/single-model-server/template.yaml
+++ b/catalogs/openshift-ai/datascience/single-model-server/template.yaml
@@ -50,6 +50,13 @@ spec:
             catalogFilter:
               - kind: Component
                 spec.type: data-science-project
+        modelName:
+          title: Model Name
+          description: The name of the Model.
+          type: string
+          pattern: "^[a-z][a-z0-9-]+$"
+          minLength: 3
+          maxLength: 30
         numGPU:
           title: Number of GPU
           description: The Number of GPUs to provide to running model.
@@ -71,13 +78,6 @@ spec:
           description: The CPU Limit for the running model(1000m).
           type: string
           default: "1000m"
-        modelName:
-          title: Model Name
-          description: The name of the Model.
-          type: string
-          pattern: "^[a-z][a-z0-9-]+$"
-          minLength: 3
-          maxLength: 30
 
     - title: Model Serving Settings
       ui:group: data-model-serving
@@ -125,7 +125,7 @@ spec:
           namespace: "${{ parameters.projectEntity | parseEntityRef | pick('name') }}"
           labels:
             project: ${{ parameters.projectEntity | parseEntityRef | pick('name') }}
-            model-server: ${{ parameters.modelName }}
+            modelServer: ${{ parameters.modelName }}
           chart:
             name: "data-single-model-server"
             chartUrl: "https://poc-examples.github.io/supporting-charts"
@@ -207,8 +207,6 @@ spec:
 
   output:
     links:
-      - title: GitOps Application
-        url: https://${{ steps['fetchSelfServiceEntity'].output.entity.spec.argocd.url }}/applications/openshift-gitops/root-self-service
       - title: GitLab Repository
         url: https://${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.instance }}/${{ steps['publishManifests'].output.projectPath }}
       - title: Open in catalog

--- a/catalogs/openshift-ai/datascience/single-model-server/template.yaml
+++ b/catalogs/openshift-ai/datascience/single-model-server/template.yaml
@@ -24,31 +24,31 @@ spec:
   type: Single-Model-Server
   parameters:
 
-    - title: ArgoCD Selection
-      ui:group: argocd
-      required:
-        - argoInstance
-      properties:
-        argoInstance:
-          title: ArgoCD Instance
-          description: The ArgoCD instance that will manage this application. Choose from available instances.
-          enum:
-            - main
-          type: string
-
     - title: Model Serving Settings
       ui:group: data-model-serving
       required:
+        - rootSelfServiceRepo
         - projectName
         - modelName
       properties:
+        rootSelfServiceRepo:
+          title: Root Self-Service Repository
+          type: string
+          description: The root self-service repository that contains artifact deployment configurations.
+          ui:field: EntityPicker
+          ui:options:
+            catalogFilter:
+              - kind: Component
+                spec.type: self-service
         projectName:
           title: Project Name
-          description: The project where the data connector is integrated.
           type: string
-          pattern: "^[a-z][a-z0-9-]+$"
-          minLength: 3
-          maxLength: 30
+          description: The project where the data connector is integrated.
+          ui:field: EntityPicker
+          ui:options:
+            catalogFilter:
+              - kind: Component
+                spec.type: data-science-project
         numGPU:
           title: Number of GPU
           description: The Number of GPUs to provide to running model.
@@ -98,27 +98,21 @@ spec:
 
   steps:
 
-    #######################
-    ## Request Dynamic Data
-    #######################
-    - id: requestDynamicData
-      name: Fetch Dynamic Data
-      action: http:backstage:request
+    #################
+    ## Fetch Entities
+    #################
+
+    - action: catalog:fetch
+      id: fetchSelfServiceEntity
+      name: Fetch Root Self-Service Repo Entity
       input:
-        method: 'POST'
-        path: 'proxy/data/fetch'
-        headers:
-          Content-Type: 'application/json'
-        body: |
-          {
-            "request": ["DOMAIN"]
-          }
+        entityRef: ${{ parameters.rootSelfServiceRepo }}
 
     ###########################
     ## Template the Application
     ###########################
     - id: applicationTemplate
-      name: Template Helm Application
+      name: Template Helm Application:template
       action: fetch:template
       input:
         url: "../../../../skeletons/applications/helm/"
@@ -176,9 +170,19 @@ spec:
         commitAction: create
         commitMessage: "Created ${{ parameters.modelName }} Model Server"
 
+    ########################
+    ## Register Catalog Info
+    ########################
+    - id: registerCatalog
+      name: "Register Catalog Info"
+      action: catalog:register
+      input:
+        repoContentsUrl: ${{ steps["publishManifests"].output.repoContentsUrl }}
+        catalogInfoPath: /model-server-entity.yaml
+
   output:
     links:
       - title: GitOps Application
-        url: https://openshift-gitops-server-openshift-gitops.apps.${{ steps['requestDynamicData'].output.body["DOMAIN"] }}/applications/openshift-gitops/root-self-service
+        url: https://${{ steps['fetchSelfServiceEntity'].output.entity.spec.argocd.url }}/applications/openshift-gitops/root-self-service
       - title: GitLab Repository
-        url: https://gitlab.apps.${{ steps['requestDynamicData'].output.body["DOMAIN"] }}/self-provisioned/manifests.git
+        url: https://${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.instance }}/${{ steps['publishManifests'].output.projectPath }}

--- a/catalogs/openshift-ai/datascience/workbench/template.yaml
+++ b/catalogs/openshift-ai/datascience/workbench/template.yaml
@@ -29,8 +29,8 @@ spec:
       ui:group: data-workbench
       required:
         - rootSelfServiceRepo
-        - projectName
-        - dataConnectorName
+        - projectEntity
+        - dataConnectorEntity
         - workbenchName
         - storageSize
       properties:
@@ -43,7 +43,7 @@ spec:
             catalogFilter:
               - kind: Component
                 spec.type: self-service
-        projectName:
+        projectEntity:
           title: Project Name
           type: string
           description: The project where the data connector is integrated.
@@ -52,7 +52,7 @@ spec:
             catalogFilter:
               - kind: Component
                 spec.type: data-science-project
-        dataConnectorName:
+        dataConnectorEntity:
           title: Data Connector Name
           type: string
           description: The name of the data connector.
@@ -116,15 +116,18 @@ spec:
       action: fetch:template
       input:
         url: "../../../../skeletons/applications/helm/"
-        targetPath: "projects/${{ parameters.projectName | parseEntityRef | pick('name') }}/"
+        targetPath: "projects/${{ parameters.projectEntity | parseEntityRef | pick('name') }}/"
         values:
           repoName: "${{ parameters.workbenchName }}-workbench"
-          namespace: "${{ parameters.projectName | parseEntityRef | pick('name') }}"
+          namespace: "${{ parameters.projectEntity | parseEntityRef | pick('name') }}"
+          labels:
+            project: ${{ parameters.projectEntity | parseEntityRef | pick('name') }}
+            workbench: ${{ parameters.workbenchName }}
           chart:
             name: "data-workbench"
             chartUrl: "https://poc-examples.github.io/supporting-charts"
             chartVersion: "0.1.19"
-          projectName: "${{ parameters.projectName | parseEntityRef | pick('name') }}"
+          projectName: "${{ parameters.projectEntity | parseEntityRef | pick('name') }}"
           automated:
             prune: true
             selfHeal: true
@@ -132,13 +135,26 @@ spec:
           valuesObject: |
             domain: ${{ steps['fetchSelfServiceEntity'].output.entity.spec.argocd.cluster }}
             user: cluster-admin
-            namespace: "${{ parameters.projectName | parseEntityRef | pick('name') }}"
+            namespace: "${{ parameters.projectEntity | parseEntityRef | pick('name') }}"
             notebookName: "${{ parameters.workbenchName }}"
             storageSize: "${{ parameters.storageSize }}"
-            dataConnectionName: "${{ parameters.dataConnectorName | parseEntityRef | pick('name') }}"
+            dataConnectionName: "${{ parameters.dataConnectorEntity | parseEntityRef | pick('name') }}"
             enabledCUDA: ${{ parameters.enableCUDA }}
             numGPU: "${{ parameters.numGPU }}"
 
+    - id: templateModelServerEntity
+      name: Template Model Server Entity
+      action: fetch:template
+      input:
+        url: "../../../../skeletons/backstage/workbench"
+        targetPath: "backstage/${{ parameters.projectEntity | parseEntityRef | pick('name') }}/"
+        values:
+          projectName: ${{ parameters.projectEntity | parseEntityRef | pick('name') }}
+          name: ${{ parameters.workbenchName }}
+          owner: user:${{ user.entity.metadata.namespace}}/${{ user.entity.metadata.name }}
+          subcomponentOf: ${{ parameters.projectEntity }}
+          dependsOn: ${{ parameters.rootSelfServiceRepo }}
+    
     ##############
     ## Rename File
     ##############
@@ -147,8 +163,16 @@ spec:
       action: fs:rename
       input:
         files:
-          - from: "projects/${{ parameters.projectName | parseEntityRef | pick('name') }}/application.yaml"
-            to: "projects/${{ parameters.projectName | parseEntityRef | pick('name') }}/${{ parameters.workbenchName }}-workbench.yaml"
+          - from: "projects/${{ parameters.projectEntity | parseEntityRef | pick('name') }}/application.yaml"
+            to: "projects/${{ parameters.projectEntity | parseEntityRef | pick('name') }}/${{ parameters.workbenchName }}-workbench.yaml"
+
+    - id: changeBackstageTemplateName
+      name: Change Backstage Template Name
+      action: fs:rename
+      input:
+        files:
+          - from: "backstage/${{ parameters.projectEntity | parseEntityRef | pick('name') }}/workbench.yaml"
+            to: "backstage/${{ parameters.projectEntity | parseEntityRef | pick('name') }}/${{ parameters.workbenchName }}-workbench.yaml"
 
     ##########################
     ## Push Repository Changes
@@ -166,9 +190,22 @@ spec:
         commitAction: create
         commitMessage: "Created ${{ parameters.workbenchName }} Workbench"
 
+    ########################
+    ## Register Catalog Info
+    ########################
+    - id: registerCatalog
+      name: "Register Catalog Info"
+      action: catalog:register
+      input:
+        repoContentsUrl: https://${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.instance }}/${{ steps["publishManifests"].output.projectPath }}
+        catalogInfoPath: /-/blob/${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.branch }}/backstage/${{ parameters.projectEntity | parseEntityRef | pick('name') }}/${{ parameters.workbenchName}}-workbench.yaml
+
   output:
     links:
       - title: GitOps Application
         url: https://${{ steps['fetchSelfServiceEntity'].output.entity.spec.argocd.url }}/applications/openshift-gitops/root-self-service
       - title: GitLab Repository
         url: https://${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.instance }}/${{ steps['publishManifests'].output.projectPath }}
+      - title: Open in catalog
+        icon: catalog
+        entityRef: ${{ steps['registerCatalog'].output.entityRef }}

--- a/catalogs/openshift-ai/datascience/workbench/template.yaml
+++ b/catalogs/openshift-ai/datascience/workbench/template.yaml
@@ -16,6 +16,7 @@ metadata:
     - automation
     - data-science
     - ai-workloads
+    - gitlab
     - argocd
 
 spec:
@@ -23,27 +24,43 @@ spec:
   system: self-service
   type: Workbench
   parameters:
-
-    - title: ArgoCD Selection
-      ui:group: argocd
-      required:
-        - argoInstance
-      properties:
-        argoInstance:
-          title: ArgoCD Instance
-          description: The ArgoCD instance that will manage this application. Choose from available instances.
-          enum:
-            - main
-          type: string
-
+                
     - title: Workbench Settings
       ui:group: data-workbench
       required:
+        - rootSelfServiceRepo
         - dataConnectorName
         - projectName
         - workbenchName
         - storageSize
       properties:
+        rootSelfServiceRepo:
+          title: Root Self-Service Repository
+          type: string
+          description: The root self-service repository that contains artifact deployment configurations.
+          ui:field: EntityPicker
+          ui:options:
+            catalogFilter:
+              - kind: Component
+                spec.type: self-service
+        projectName:
+          title: Project Name
+          type: string
+          description: The project where the data connector is integrated.
+          ui:field: EntityPicker
+          ui:options:
+            catalogFilter:
+              - kind: Component
+                spec.type: data-science-project
+        dataConnectorName:
+          title: Data Connector Name
+          type: string
+          description: The name of the data connector.
+          ui:field: EntityPicker
+          ui:options:
+            catalogFilter:
+              - kind: Component
+                spec.type: data-connector
         enableCUDA:
           title: Enable CUDA
           description: Enables CUDA support for Workbench.
@@ -63,20 +80,6 @@ spec:
             - 2
             - 3
             - 4
-        dataConnectorName:
-          title: Data Connector Name
-          description: The name of the data connector.
-          type: string
-          pattern: "^[a-z][a-z0-9-]+$"
-          minLength: 3
-          maxLength: 30
-        projectName:
-          title: Project Name
-          description: The project where the data connector is integrated.
-          type: string
-          pattern: "^[a-z][a-z0-9-]+$"
-          minLength: 3
-          maxLength: 30
         workbenchName:
           title: Workbench Name
           description: The name of the workbench.
@@ -95,21 +98,15 @@ spec:
 
   steps:
 
-    #######################
-    ## Request Dynamic Data
-    #######################
-    - id: requestDynamicData
-      name: Fetch Dynamic Data
-      action: http:backstage:request
+    #################
+    ## Fetch Entities
+    #################
+
+    - action: catalog:fetch
+      id: fetchSelfServiceEntity
+      name: Fetch Root Self-Service Repo Entity
       input:
-        method: 'POST'
-        path: 'proxy/data/fetch'
-        headers:
-          Content-Type: 'application/json'
-        body: |
-          {
-            "request": ["DOMAIN"]
-          }
+        entityRef: ${{ parameters.rootSelfServiceRepo }}
 
     ###########################
     ## Template the Application
@@ -133,7 +130,7 @@ spec:
             selfHeal: true
           createNamespace: "true"
           valuesObject: |
-            domain: ${{ steps['requestDynamicData'].output.body["DOMAIN"] }}
+            domain: ${{ steps['fetchSelfServiceEntity'].output.entity.spec.argocd.cluster }}
             user: cluster-admin
             namespace: "${{ parameters.projectName }}"
             notebookName: "${{ parameters.workbenchName }}"
@@ -161,19 +158,19 @@ spec:
       action: gitlab:repo:push
       input:
         allowedHosts:
-          - 'gitlab.com'
+          - ${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.instance }}
         description: |
           placeholder
-        repoUrl: gitlab.com?owner=self-provisioned&repo=manifests
+        repoUrl: ${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.instance }}?owner=${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.owner }}&repo=${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.repository }}
         sourcePath: "./projects/${{ parameters.projectName }}"
         targetPath: "./projects/${{ parameters.projectName }}"
-        branchName: main
+        branchName: ${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.branch }}
         commitAction: create
         commitMessage: "Created ${{ parameters.workbenchName }} Workbench"
 
   output:
     links:
       - title: GitOps Application
-        url: https://openshift-gitops-server-openshift-gitops.apps.${{ steps['requestDynamicData'].output.body["DOMAIN"] }}/applications/openshift-gitops/root-self-service
+        url: https://${{ steps['fetchSelfServiceEntity'].output.entity.spec.argocd.url }}/applications/openshift-gitops/root-self-service
       - title: GitLab Repository
-        url: https://gitlab.apps.${{ steps['requestDynamicData'].output.body["DOMAIN"] }}/self-provisioned/manifests.git
+        url: https://${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.instance }}/${{ steps['publishManifests'].output.projectPath }}

--- a/catalogs/openshift-ai/datascience/workbench/template.yaml
+++ b/catalogs/openshift-ai/datascience/workbench/template.yaml
@@ -29,8 +29,8 @@ spec:
       ui:group: data-workbench
       required:
         - rootSelfServiceRepo
-        - dataConnectorName
         - projectName
+        - dataConnectorName
         - workbenchName
         - storageSize
       properties:
@@ -116,15 +116,15 @@ spec:
       action: fetch:template
       input:
         url: "../../../../skeletons/applications/helm/"
-        targetPath: "projects/${{ parameters.projectName }}/"
+        targetPath: "projects/${{ parameters.projectName | parseEntityRef | pick('name') }}/"
         values:
           repoName: "${{ parameters.workbenchName }}-workbench"
-          namespace: "${{ parameters.projectName }}"
+          namespace: "${{ parameters.projectName | parseEntityRef | pick('name') }}"
           chart:
             name: "data-workbench"
             chartUrl: "https://poc-examples.github.io/supporting-charts"
             chartVersion: "0.1.19"
-          projectName: "${{ parameters.projectName }}"
+          projectName: "${{ parameters.projectName | parseEntityRef | pick('name') }}"
           automated:
             prune: true
             selfHeal: true
@@ -132,10 +132,10 @@ spec:
           valuesObject: |
             domain: ${{ steps['fetchSelfServiceEntity'].output.entity.spec.argocd.cluster }}
             user: cluster-admin
-            namespace: "${{ parameters.projectName }}"
+            namespace: "${{ parameters.projectName | parseEntityRef | pick('name') }}"
             notebookName: "${{ parameters.workbenchName }}"
             storageSize: "${{ parameters.storageSize }}"
-            dataConnectionName: "${{ parameters.dataConnectorName }}"
+            dataConnectionName: "${{ parameters.dataConnectorName | parseEntityRef | pick('name') }}"
             enabledCUDA: ${{ parameters.enableCUDA }}
             numGPU: "${{ parameters.numGPU }}"
 
@@ -147,8 +147,8 @@ spec:
       action: fs:rename
       input:
         files:
-          - from: "projects/${{ parameters.projectName }}/application.yaml"
-            to: "projects/${{ parameters.projectName }}/${{ parameters.workbenchName }}-workbench.yaml"
+          - from: "projects/${{ parameters.projectName | parseEntityRef | pick('name') }}/application.yaml"
+            to: "projects/${{ parameters.projectName | parseEntityRef | pick('name') }}/${{ parameters.workbenchName }}-workbench.yaml"
 
     ##########################
     ## Push Repository Changes
@@ -162,8 +162,6 @@ spec:
         description: |
           placeholder
         repoUrl: ${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.instance }}?owner=${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.owner }}&repo=${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.repository }}
-        sourcePath: "./projects/${{ parameters.projectName }}"
-        targetPath: "./projects/${{ parameters.projectName }}"
         branchName: ${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.branch }}
         commitAction: create
         commitMessage: "Created ${{ parameters.workbenchName }} Workbench"

--- a/catalogs/openshift-ai/datascience/workbench/template.yaml
+++ b/catalogs/openshift-ai/datascience/workbench/template.yaml
@@ -61,6 +61,13 @@ spec:
             catalogFilter:
               - kind: Component
                 spec.type: data-connector
+        workbenchName:
+          title: Workbench Name
+          description: The name of the workbench.
+          type: string
+          pattern: "^[a-z][a-z0-9-]+$"
+          minLength: 3
+          maxLength: 30
         enableCUDA:
           title: Enable CUDA
           description: Enables CUDA support for Workbench.
@@ -80,13 +87,6 @@ spec:
             - 2
             - 3
             - 4
-        workbenchName:
-          title: Workbench Name
-          description: The name of the workbench.
-          type: string
-          pattern: "^[a-z][a-z0-9-]+$"
-          minLength: 3
-          maxLength: 30
         storageSize:
           title: Storage Size
           description: The storage size of the workbench working directory.
@@ -133,7 +133,7 @@ spec:
             selfHeal: true
           createNamespace: "true"
           valuesObject: |
-            domain: ${{ steps['fetchSelfServiceEntity'].output.entity.spec.argocd.cluster }}
+            domain: main
             user: cluster-admin
             namespace: "${{ parameters.projectEntity | parseEntityRef | pick('name') }}"
             notebookName: "${{ parameters.workbenchName }}"
@@ -202,8 +202,6 @@ spec:
 
   output:
     links:
-      - title: GitOps Application
-        url: https://${{ steps['fetchSelfServiceEntity'].output.entity.spec.argocd.url }}/applications/openshift-gitops/root-self-service
       - title: GitLab Repository
         url: https://${{ steps['fetchSelfServiceEntity'].output.entity.spec.gitlab.instance }}/${{ steps['publishManifests'].output.projectPath }}
       - title: Open in catalog

--- a/devfiles/continue-workspace/devfile.yaml
+++ b/devfiles/continue-workspace/devfile.yaml
@@ -1,6 +1,6 @@
 schemaVersion: 2.2.0
 metadata:
-  name: minimal-vscode-workspace
+  name: ai-enabled-codespace
 projects:
   - name: software-templates
     git: 

--- a/skeletons/applications/helm/application.yaml
+++ b/skeletons/applications/helm/application.yaml
@@ -12,13 +12,13 @@ metadata:
   {%- if values.labels.project %}
   labels:
     backstage-name: ${{ values.labels.project }}
-    {%- if values.labels.data-connector|length %}
-    data-connector: ${{ values.labels.data-connector }}
+    {%- if values.labels.dataConnector.length %}
+    dataconnector: ${{ values.labels.dataConnector }}
     {%- endif %}
-    {%- if values.labels.model-server|length %}
-    model-server: ${{ values.labels.model-server }}
+    {%- if values.labels.modelServer.length %}
+    modelserver: ${{ values.labels.modelServer }}
     {%- endif %}
-    {%- if values.labels.workbench|length %}
+    {%- if values.labels.workbench.length %}
     workbench: ${{ values.labels.workbench }}
     {%- endif %}
   {%- endif %}

--- a/skeletons/applications/helm/application.yaml
+++ b/skeletons/applications/helm/application.yaml
@@ -9,6 +9,19 @@ metadata:
     {%- else %}
     argocd.argoproj.io/sync-wave: "1"
     {%- endif %}
+  {%- if values.labels.project %}
+  labels:
+    backstage-name: ${{ values.labels.project }}
+    {%- if values.labels.data-connector|length %}
+    data-connector: ${{ values.labels.data-connector }}
+    {%- endif %}
+    {%- if values.labels.model-server|length %}
+    model-server: ${{ values.labels.model-server }}
+    {%- endif %}
+    {%- if values.labels.workbench|length %}
+    workbench: ${{ values.labels.workbench }}
+    {%- endif %}
+  {%- endif %}
 spec:
   destination:
     namespace: "${{ values.namespace }}"

--- a/skeletons/backstage/data-connector/data-connector.yaml
+++ b/skeletons/backstage/data-connector/data-connector.yaml
@@ -3,6 +3,8 @@ kind: Component
 metadata:
   name: ${{ values.name }}
   description: Data connector
+  annotations:
+    argocd/app-selector: backstage-name=${{ values.projectName }},data-connector=${{ values.name }}
   tags:
     - data-connector
 spec:

--- a/skeletons/backstage/data-connector/data-connector.yaml
+++ b/skeletons/backstage/data-connector/data-connector.yaml
@@ -1,0 +1,14 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: ${{ values.name }}
+  description: Data connector
+  tags:
+    - data-connector
+spec:
+  type: data-connector
+  lifecycle: production
+  owner: ${{ values.owner }}
+  subcomponentOf: ${{ values.subcomponentOf }}
+  dependsOn:
+    - ${{ values.dependsOn }}

--- a/skeletons/backstage/data-connector/data-connector.yaml
+++ b/skeletons/backstage/data-connector/data-connector.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ${{ values.name }}
   description: Data connector
   annotations:
-    argocd/app-selector: backstage-name=${{ values.projectName }},data-connector=${{ values.name }}
+    argocd/app-selector: backstage-name=${{ values.projectName }},dataconnector=${{ values.name }}
   tags:
     - data-connector
 spec:

--- a/skeletons/backstage/data-science-project/data-science-project.yaml
+++ b/skeletons/backstage/data-science-project/data-science-project.yaml
@@ -3,6 +3,8 @@ kind: Component
 metadata:
   name: ${{ values.name }}
   description: Data science project
+  annotations:
+    argocd/app-selector: backstage-name=${{ values.name }}
   tags:
     - data-science-project
 spec:

--- a/skeletons/backstage/data-science-project/data-science-project.yaml
+++ b/skeletons/backstage/data-science-project/data-science-project.yaml
@@ -1,0 +1,13 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: ${{ values.name }}
+  description: Data science project
+  tags:
+    - data-science-project
+spec:
+  type: data-science-project
+  lifecycle: production
+  owner: ${{ values.owner }}
+  dependsOn:
+    - ${{ values.dependsOn }}

--- a/skeletons/backstage/model-server/model-server.yaml
+++ b/skeletons/backstage/model-server/model-server.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ${{ values.name }}
   description: Model server
   annotations:
-    argocd/app-selector: backstage-name=${{ values.projectName }},model-server=${{ values.name }}
+    argocd/app-selector: backstage-name=${{ values.projectName }},modelserver=${{ values.name }}
   tags:
     - model-server
 spec:

--- a/skeletons/backstage/model-server/model-server.yaml
+++ b/skeletons/backstage/model-server/model-server.yaml
@@ -9,3 +9,6 @@ spec:
   type: model-server
   lifecycle: production
   owner: ${{ values.owner }}
+  subcomponentOf: ${{ values.subcomponentOf }}
+  dependsOn:
+    - ${{ values.dependsOn }}

--- a/skeletons/backstage/model-server/model-server.yaml
+++ b/skeletons/backstage/model-server/model-server.yaml
@@ -1,0 +1,11 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: ${{ values.name }}
+  description: Model server
+  tags:
+    - model-server
+spec:
+  type: model-server
+  lifecycle: production
+  owner: ${{ values.owner }}

--- a/skeletons/backstage/workbench/workbench.yaml
+++ b/skeletons/backstage/workbench/workbench.yaml
@@ -2,13 +2,13 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: ${{ values.name }}
-  description: Model server
+  description: Workbench
   annotations:
-    argocd/app-selector: backstage-name=${{ values.projectName }},model-server=${{ values.name }}
+    argocd/app-selector: backstage-name=${{ values.projectName }},workbench=${{ values.name }}
   tags:
-    - model-server
+    - workbench
 spec:
-  type: model-server
+  type: workbench
   lifecycle: production
   owner: ${{ values.owner }}
   subcomponentOf: ${{ values.subcomponentOf }}


### PR DESCRIPTION
- *** **Still haven't implemented model-server and workbench template updates yet** ***
- Using entities of `kind: Component` and `type: data-science-project`, `data-connector`, and `model-server`.
- Created separate folder for backstage entities in Git repo, separate from ArgoCD objects in project